### PR TITLE
优化 PPTX 翻译稳定性与工作台体验

### DIFF
--- a/app/function/pynuo_fuc/pptx_xml_manifest.py
+++ b/app/function/pynuo_fuc/pptx_xml_manifest.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import re
+import zipfile
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Final
+from xml.etree import ElementTree
+
+from app.translation.pptx_contract_types import (
+    PptxContext,
+    PptxGlossaryEntry,
+    PptxLineBreakStreamItem,
+    PptxProtectedFieldStreamItem,
+    PptxRequestUnit,
+    PptxSourceStreamItem,
+    PptxTextStreamItem,
+)
+
+from .pptx_xml_types import (
+    PptxXmlDuplicateShapeIdError,
+    PptxXmlReadError,
+    PptxXmlUnsupportedStructureError,
+)
+from .pptx_xml_manifest_support import (
+    is_title as _is_title,
+    is_translatable_text as _is_translatable_text,
+    layout_hint as _layout_hint,
+    local_name as _local_name,
+    shape_id as _shape_id,
+    shape_owner as _shape_owner,
+    stream_text as _stream_text,
+    text_bodies as _text_bodies,
+)
+
+
+A_NS: Final = "http://schemas.openxmlformats.org/drawingml/2006/main"
+A_P: Final = f"{{{A_NS}}}p"
+A_R: Final = f"{{{A_NS}}}r"
+A_T: Final = f"{{{A_NS}}}t"
+A_BR: Final = f"{{{A_NS}}}br"
+A_FLD: Final = f"{{{A_NS}}}fld"
+A_P_PR: Final = f"{{{A_NS}}}pPr"
+A_END_PARA_RPR: Final = f"{{{A_NS}}}endParaRPr"
+SLIDE_PATH_RE: Final = re.compile(r"^ppt/slides/slide(\d+)\.xml$")
+
+
+@dataclass(frozen=True, slots=True)
+class StructuredParagraphTarget:
+    unit: PptxRequestUnit
+    page_index: int
+    box_index: int
+    paragraph_index: int
+    paragraph: ElementTree.Element
+    text_body: ElementTree.Element
+    content_nodes: tuple[ElementTree.Element, ...]
+    segment_nodes: tuple[tuple[str, ElementTree.Element], ...]
+    is_title: bool
+
+
+def extract_structured_units_from_pptx(
+    pptx_path: Path | str,
+    selected_page_indices: Sequence[int] | None = None,
+    *,
+    source_language: str,
+    target_language: str,
+    stop_words: Sequence[str] = (),
+    custom_translations: Mapping[str, str] | None = None,
+) -> tuple[PptxRequestUnit, ...]:
+    selected = set(selected_page_indices) if selected_page_indices else None
+    glossary = tuple(
+        PptxGlossaryEntry(source, target)
+        for source, target in sorted((custom_translations or {}).items())
+    )
+    units: list[PptxRequestUnit] = []
+    try:
+        with zipfile.ZipFile(pptx_path) as archive:
+            for page_index, slide_path in enumerate(slide_paths(archive)):
+                if selected is not None and page_index not in selected:
+                    continue
+                root = ElementTree.fromstring(archive.read(slide_path))
+                targets = structured_slide_targets(
+                    root,
+                    page_index,
+                    slide_path,
+                    source_language,
+                    target_language,
+                    tuple(stop_words),
+                    glossary,
+                )
+                units.extend(target.unit for target in _with_context(targets))
+    except (OSError, zipfile.BadZipFile, ElementTree.ParseError) as exc:
+        raise PptxXmlReadError("archive or slide XML is invalid") from exc
+    return tuple(units)
+
+
+def structured_slide_targets(
+    root: ElementTree.Element,
+    page_index: int,
+    slide_path: str,
+    source_language: str,
+    target_language: str,
+    stop_words: tuple[str, ...],
+    glossary: tuple[PptxGlossaryEntry, ...],
+) -> tuple[StructuredParagraphTarget, ...]:
+    parents = {child: parent for parent in root.iter() for child in parent}
+    owner_ordinals: defaultdict[ElementTree.Element, int] = defaultdict(int)
+    ownerless_ordinal = 0
+    shape_owners: dict[str, ElementTree.Element] = {}
+    targets: list[StructuredParagraphTarget] = []
+    for box_index, text_body in enumerate(_text_bodies(root)):
+        owner = _shape_owner(text_body, parents)
+        shape_id = _shape_id(owner)
+        if owner is not None and shape_id is not None:
+            previous_owner = shape_owners.get(shape_id)
+            if previous_owner is not None and previous_owner is not owner:
+                raise PptxXmlDuplicateShapeIdError(slide_path, shape_id)
+            shape_owners[shape_id] = owner
+            text_body_key = f"shapeId{shape_id}:tbOrdinal{owner_ordinals[owner]}"
+            owner_ordinals[owner] += 1
+        else:
+            text_body_key = f"slideTbOrdinal{ownerless_ordinal}"
+            ownerless_ordinal += 1
+        unit_prefix = f"pptx:slide{slide_number(slide_path)}:{text_body_key}"
+        paragraph_index = 0
+        for paragraph in list(text_body):
+            if paragraph.tag != A_P:
+                continue
+            target = _paragraph_target(
+                paragraph,
+                text_body,
+                owner,
+                page_index,
+                box_index,
+                paragraph_index,
+                f"{unit_prefix}:p{paragraph_index}",
+                slide_path,
+                source_language,
+                target_language,
+                stop_words,
+                glossary,
+            )
+            if target is not None:
+                targets.append(target)
+            paragraph_index += 1
+    return tuple(targets)
+
+
+def slide_paths(archive: zipfile.ZipFile) -> list[str]:
+    paths = [name for name in archive.namelist() if SLIDE_PATH_RE.match(name)]
+    return sorted(paths, key=slide_number)
+
+
+def slide_number(path: str) -> int:
+    match = SLIDE_PATH_RE.match(path)
+    return int(match.group(1)) if match else 0
+
+
+def _paragraph_target(
+    paragraph: ElementTree.Element,
+    text_body: ElementTree.Element,
+    owner: ElementTree.Element | None,
+    page_index: int,
+    box_index: int,
+    paragraph_index: int,
+    unit_id: str,
+    slide_path: str,
+    source_language: str,
+    target_language: str,
+    stop_words: tuple[str, ...],
+    glossary: tuple[PptxGlossaryEntry, ...],
+) -> StructuredParagraphTarget | None:
+    stream: list[PptxSourceStreamItem] = []
+    content_nodes: list[ElementTree.Element] = []
+    segment_nodes: list[tuple[str, ElementTree.Element]] = []
+    content_index = 0
+    for child in list(paragraph):
+        if child.tag in (A_P_PR, A_END_PARA_RPR):
+            continue
+        stream_id = f"{unit_id}:stream{content_index}"
+        if child.tag == A_R:
+            text_nodes = list(child.iter(A_T))
+            if len(text_nodes) != 1:
+                raise PptxXmlUnsupportedStructureError(slide_path, "text run must contain exactly one a:t")
+            segment_id = f"{unit_id}:segment{content_index}"
+            source_text = text_nodes[0].text or ""
+            stream.append(PptxTextStreamItem(stream_id, segment_id, source_text))
+            segment_nodes.append((segment_id, text_nodes[0]))
+            content_nodes.append(child)
+            content_index += 1
+            continue
+        if child.tag == A_BR:
+            stream.append(PptxLineBreakStreamItem(stream_id))
+            content_nodes.append(child)
+            content_index += 1
+            continue
+        if child.tag == A_FLD:
+            source_text = "".join(node.text or "" for node in child.iter(A_T))
+            stream.append(PptxProtectedFieldStreamItem(stream_id, source_text))
+            content_nodes.append(child)
+            content_index += 1
+            continue
+        if any(True for _ in child.iter(A_T)):
+            raise PptxXmlUnsupportedStructureError(slide_path, f"unsupported text node {_local_name(child.tag)}")
+    text = _stream_text(tuple(stream))
+    if not segment_nodes or not _is_translatable_text(text):
+        return None
+    unit = PptxRequestUnit(
+        unit_id=unit_id,
+        source_text=text,
+        source_stream=tuple(stream),
+        source_language=source_language,
+        target_language=target_language,
+        layout_hint=_layout_hint(owner),
+        glossary=glossary,
+        protected_terms=stop_words,
+    )
+    return StructuredParagraphTarget(
+        unit,
+        page_index,
+        box_index,
+        paragraph_index,
+        paragraph,
+        text_body,
+        tuple(content_nodes),
+        tuple(segment_nodes),
+        _is_title(owner),
+    )
+
+
+def _with_context(
+    targets: tuple[StructuredParagraphTarget, ...],
+) -> tuple[StructuredParagraphTarget, ...]:
+    title = next((target.unit.source_text for target in targets if target.is_title), "")
+    enriched: list[StructuredParagraphTarget] = []
+    for index, target in enumerate(targets):
+        context = PptxContext(
+            previous_text=targets[index - 1].unit.source_text if index else "",
+            next_text=targets[index + 1].unit.source_text if index + 1 < len(targets) else "",
+            title_text=title,
+        )
+        enriched.append(replace(target, unit=replace(target.unit, context=context)))
+    return tuple(enriched)

--- a/app/function/pynuo_fuc/pptx_xml_manifest_support.py
+++ b/app/function/pynuo_fuc/pptx_xml_manifest_support.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import re
+from typing import Final, assert_never
+from xml.etree import ElementTree
+
+from app.translation.pptx_contract_types import (
+    PptxLayoutHint,
+    PptxLineBreakStreamItem,
+    PptxProtectedFieldStreamItem,
+    PptxSourceStreamItem,
+    PptxTextStreamItem,
+)
+
+
+SHAPE_OWNER_NAMES: Final = frozenset({"sp", "graphicFrame", "cxnSp", "pic", "contentPart"})
+
+
+def text_bodies(root: ElementTree.Element) -> tuple[ElementTree.Element, ...]:
+    return tuple(item for item in root.iter() if local_name(item.tag) == "txBody")
+
+
+def shape_owner(
+    text_body: ElementTree.Element,
+    parents: dict[ElementTree.Element, ElementTree.Element],
+) -> ElementTree.Element | None:
+    current = parents.get(text_body)
+    while current is not None:
+        if local_name(current.tag) in SHAPE_OWNER_NAMES:
+            return current
+        current = parents.get(current)
+    return None
+
+
+def shape_id(owner: ElementTree.Element | None) -> str | None:
+    node = _shape_properties(owner)
+    return node.get("id") if node is not None else None
+
+
+def is_title(owner: ElementTree.Element | None) -> bool:
+    node = _shape_properties(owner)
+    if node is not None and any(
+        token in node.get("name", "").casefold()
+        for token in ("title", "标题")
+    ):
+        return True
+    if owner is None:
+        return False
+    placeholder = next((item for item in owner.iter() if local_name(item.tag) == "ph"), None)
+    return placeholder is not None and placeholder.get("type", "") in ("title", "ctrTitle")
+
+
+def layout_hint(owner: ElementTree.Element | None) -> PptxLayoutHint:
+    if owner is None:
+        return PptxLayoutHint()
+    transform = next((item for item in owner.iter() if local_name(item.tag) == "xfrm"), None)
+    if transform is None:
+        return PptxLayoutHint()
+    offset = next((item for item in transform if local_name(item.tag) == "off"), None)
+    extent = next((item for item in transform if local_name(item.tag) == "ext"), None)
+    return PptxLayoutHint(
+        x_emu=_optional_int(offset.get("x")) if offset is not None else None,
+        y_emu=_optional_int(offset.get("y")) if offset is not None else None,
+        width_emu=_optional_positive_int(extent.get("cx")) if extent is not None else None,
+        height_emu=_optional_positive_int(extent.get("cy")) if extent is not None else None,
+    )
+
+
+def stream_text(stream: tuple[PptxSourceStreamItem, ...]) -> str:
+    parts: list[str] = []
+    for item in stream:
+        match item:
+            case PptxTextStreamItem():
+                parts.append(item.source_text)
+            case PptxLineBreakStreamItem():
+                parts.append("\n")
+            case PptxProtectedFieldStreamItem():
+                parts.append(item.source_text)
+            case _ as unreachable:
+                assert_never(unreachable)
+    return "".join(parts)
+
+
+def is_translatable_text(text: str) -> bool:
+    stripped = text.strip()
+    if not stripped or re.fullmatch(r"[\d\s.,%+\-]+", stripped):
+        return False
+    return not re.fullmatch(r"[\W_]+", stripped, re.UNICODE)
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _shape_properties(owner: ElementTree.Element | None) -> ElementTree.Element | None:
+    if owner is None:
+        return None
+    return next((item for item in owner.iter() if local_name(item.tag) == "cNvPr"), None)
+
+
+def _optional_int(value: str | None) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except ValueError:
+        return None
+
+
+def _optional_positive_int(value: str | None) -> int | None:
+    parsed = _optional_int(value)
+    return parsed if parsed is not None and parsed > 0 else None

--- a/app/function/pynuo_fuc/pptx_xml_ops.py
+++ b/app/function/pynuo_fuc/pptx_xml_ops.py
@@ -1,20 +1,39 @@
+"""Legacy-compatible XML operations.
+
+# noqa: SIZE_OK - legacy writer remains intact while V2 responsibilities live in focused modules.
+"""
+
 from __future__ import annotations
 
 import copy
 import logging
+import os
 import re
+import tempfile
 import zipfile
 from collections.abc import Mapping, Sequence
+from io import BytesIO
 from pathlib import Path
+from threading import Lock
 from typing import Final, assert_never
 from xml.etree import ElementTree
 
+from app.translation.pptx_contract import PptxContractError, reserved_marker_counts
+from app.translation.pptx_contract_types import PptxRequestUnit, PptxUnitTranslation
+
 try:
     from .pptx_xml_autofit import enable_textbox_autofit_for_paragraph
+    from .pptx_xml_package import serialize_slide_xml, validate_pptx_package
     from .pptx_xml_types import TextBoxData, TranslationPageResult, WriteMode, XmlParagraphTarget
 except ImportError:
-    from pptx_xml_autofit import enable_textbox_autofit_for_paragraph
-    from pptx_xml_types import TextBoxData, TranslationPageResult, WriteMode, XmlParagraphTarget
+    from app.function.pynuo_fuc.pptx_xml_autofit import enable_textbox_autofit_for_paragraph
+    from app.function.pynuo_fuc.pptx_xml_package import serialize_slide_xml, validate_pptx_package
+    from app.function.pynuo_fuc.pptx_xml_types import (
+        TextBoxData,
+        TranslationPageResult,
+        WriteMode,
+        XmlParagraphTarget,
+    )
 
 
 logger = logging.getLogger(__name__)
@@ -35,6 +54,50 @@ A_BR: Final = f"{{{A_NS}}}br"
 A_END_PARA_RPR: Final = f"{{{A_NS}}}endParaRPr"
 XML_SPACE: Final = f"{{{XML_NS}}}space"
 SLIDE_PATH_RE: Final = re.compile(r"^ppt/slides/slide(\d+)\.xml$")
+RESERVED_NAMESPACE_PREFIX_RE: Final = re.compile(r"ns\d+$")
+NAMESPACE_SERIALIZATION_LOCK: Final = Lock()
+
+
+def extract_structured_units_from_pptx(
+    pptx_path: Path | str,
+    selected_page_indices: Sequence[int] | None = None,
+    *,
+    source_language: str,
+    target_language: str,
+    stop_words: Sequence[str] = (),
+    custom_translations: Mapping[str, str] | None = None,
+) -> tuple[PptxRequestUnit, ...]:
+    try:
+        from .pptx_xml_manifest import extract_structured_units_from_pptx as extract
+    except ImportError:
+        from app.function.pynuo_fuc.pptx_xml_manifest import (
+            extract_structured_units_from_pptx as extract,
+        )
+
+    return extract(
+        pptx_path,
+        selected_page_indices,
+        source_language=source_language,
+        target_language=target_language,
+        stop_words=stop_words,
+        custom_translations=custom_translations,
+    )
+
+
+def write_structured_translated_pptx(
+    input_path: Path | str,
+    output_path: Path | str,
+    translations: tuple[PptxUnitTranslation, ...],
+    bilingual_translation: str,
+) -> str:
+    try:
+        from .pptx_xml_structured import write_structured_translated_pptx as write
+    except ImportError:
+        from app.function.pynuo_fuc.pptx_xml_structured import (
+            write_structured_translated_pptx as write,
+        )
+
+    return write(input_path, output_path, translations, bilingual_translation)
 
 
 def extract_text_boxes_data_from_pptx(
@@ -74,26 +137,39 @@ def write_translated_pptx_xml(
     output_file.parent.mkdir(parents=True, exist_ok=True)
     translation_lookup = _build_translation_lookup(text_boxes_data, translation_results)
     pages_to_modify = {page for page, _, _ in translation_lookup}
-
-    with zipfile.ZipFile(input_file) as source, zipfile.ZipFile(
-        output_file,
-        "w",
-        zipfile.ZIP_DEFLATED,
-    ) as target:
-        slide_paths = _slide_paths(source)
-        slide_index_by_path = {slide_path: index for index, slide_path in enumerate(slide_paths)}
-        for item in source.infolist():
-            data = source.read(item.filename)
-            page_index = slide_index_by_path.get(item.filename)
-            if page_index in pages_to_modify:
-                data = _translated_slide_xml(
-                    data,
-                    item.filename,
-                    page_index,
-                    translation_lookup,
-                    _resolve_write_mode(bilingual_translation),
-                )
-            target.writestr(item, data)
+    with tempfile.NamedTemporaryFile(
+        prefix=f".{output_file.stem}.",
+        suffix=".tmp.pptx",
+        dir=output_file.parent,
+        delete=False,
+    ) as temporary:
+        temporary_path = Path(temporary.name)
+    try:
+        with zipfile.ZipFile(input_file) as source, zipfile.ZipFile(
+            temporary_path,
+            "w",
+            zipfile.ZIP_DEFLATED,
+        ) as target:
+            expected_members = tuple(source.namelist())
+            target.comment = source.comment
+            slide_paths = _slide_paths(source)
+            slide_index_by_path = {slide_path: index for index, slide_path in enumerate(slide_paths)}
+            for item in source.infolist():
+                data = source.read(item.filename)
+                page_index = slide_index_by_path.get(item.filename)
+                if page_index in pages_to_modify:
+                    data = _translated_slide_xml(
+                        data,
+                        item.filename,
+                        page_index,
+                        translation_lookup,
+                        _resolve_write_mode(bilingual_translation),
+                    )
+                target.writestr(item, data)
+        validate_pptx_package(temporary_path, expected_members)
+        os.replace(temporary_path, output_file)
+    finally:
+        temporary_path.unlink(missing_ok=True)
     return str(output_file)
 
 
@@ -174,6 +250,14 @@ def _build_translation_lookup(
         key = f"{item['box_index'] + 1}_{item['paragraph_index'] + 1}"
         fragments = tuple(fragment for fragment in fragments_by_key.get(key, ()) if fragment)
         if fragments:
+            if reserved_marker_counts(item["combined_text"]) != reserved_marker_counts(
+                "".join(fragments),
+            ):
+                raise PptxContractError(
+                    "reserved_marker_added",
+                    "legacy translation changed reserved marker provenance",
+                    item["paragraph_id"],
+                )
             lookup[(page_index, item["box_index"], item["paragraph_index"])] = fragments
     return lookup
 
@@ -185,13 +269,22 @@ def _translated_slide_xml(
     translation_lookup: Mapping[tuple[int, int, int], Sequence[str]],
     mode: WriteMode,
 ) -> bytes:
-    root = ElementTree.fromstring(slide_data)
-    for target in _paragraph_targets(root, page_index, slide_path):
-        fragments = translation_lookup.get((page_index, target.box_index, target.paragraph_index))
-        if fragments:
-            enable_textbox_autofit_for_paragraph(root, target.paragraph)
-            _apply_translation(target, tuple(fragments), mode)
-    return ElementTree.tostring(root, encoding="utf-8", xml_declaration=True)
+    with NAMESPACE_SERIALIZATION_LOCK:
+        _register_source_namespaces(slide_data)
+        root = ElementTree.fromstring(slide_data)
+        for target in _paragraph_targets(root, page_index, slide_path):
+            fragments = translation_lookup.get((page_index, target.box_index, target.paragraph_index))
+            if fragments:
+                enable_textbox_autofit_for_paragraph(root, target.paragraph)
+                _apply_translation(target, tuple(fragments), mode)
+    return serialize_slide_xml(slide_data, root)
+
+
+def _register_source_namespaces(xml_data: bytes) -> None:
+    for _, namespace in ElementTree.iterparse(BytesIO(xml_data), events=("start-ns",)):
+        prefix, uri = namespace
+        if not RESERVED_NAMESPACE_PREFIX_RE.fullmatch(prefix):
+            ElementTree.register_namespace(prefix, uri)
 
 
 def _apply_translation(

--- a/app/function/pynuo_fuc/pptx_xml_package.py
+++ b/app/function/pynuo_fuc/pptx_xml_package.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import re
+import posixpath
+import zipfile
+from io import BytesIO
+from pathlib import Path
+from threading import Lock
+from typing import Final
+from xml.etree import ElementTree
+from xml.sax.saxutils import quoteattr
+from urllib.parse import unquote
+
+from .pptx_xml_types import PptxXmlPackageError
+
+
+MC_NS: Final = "http://schemas.openxmlformats.org/markup-compatibility/2006"
+MC_CHOICE: Final = f"{{{MC_NS}}}Choice"
+RESERVED_NAMESPACE_PREFIX_RE: Final = re.compile(r"ns\d+$")
+NAMESPACE_SERIALIZATION_LOCK: Final = Lock()
+REQUIRED_MEMBERS: Final = frozenset({"[Content_Types].xml", "ppt/presentation.xml"})
+RELATIONSHIP_NS: Final = "http://schemas.openxmlformats.org/package/2006/relationships"
+RELATIONSHIP_TAG: Final = f"{{{RELATIONSHIP_NS}}}Relationship"
+
+
+def serialize_slide_xml(source_data: bytes, root: ElementTree.Element) -> bytes:
+    source_namespaces = _namespace_map(source_data)
+    required = _required_prefixes(root)
+    with NAMESPACE_SERIALIZATION_LOCK:
+        for prefix, uri in source_namespaces.items():
+            if not RESERVED_NAMESPACE_PREFIX_RE.fullmatch(prefix):
+                ElementTree.register_namespace(prefix, uri)
+        serialized = ElementTree.tostring(root, encoding="utf-8", xml_declaration=True)
+    declared = _namespace_map(serialized)
+    missing = {
+        prefix: source_namespaces[prefix]
+        for prefix in required
+        if prefix not in declared and prefix in source_namespaces
+    }
+    unresolved = required - declared.keys() - missing.keys()
+    if unresolved:
+        raise PptxXmlPackageError("compatibility markup references an undeclared namespace")
+    return _inject_root_namespaces(serialized, missing)
+
+
+def validate_pptx_package(
+    path: Path,
+    expected_members: tuple[str, ...],
+) -> None:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            names = archive.namelist()
+            if len(names) != len(set(names)):
+                raise PptxXmlPackageError("archive contains duplicate members")
+            if tuple(names) != expected_members:
+                raise PptxXmlPackageError("archive member inventory changed")
+            if not REQUIRED_MEMBERS.issubset(names):
+                raise PptxXmlPackageError("archive is missing a required member")
+            if archive.testzip() is not None:
+                raise PptxXmlPackageError("archive CRC validation failed")
+            for name in names:
+                if name.endswith((".xml", ".rels")) or name == "[Content_Types].xml":
+                    _validate_xml_part(name, archive.read(name))
+                if name.endswith(".rels"):
+                    _validate_relationship_targets(name, archive.read(name), frozenset(names))
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise PptxXmlPackageError("output is not a readable ZIP package") from exc
+
+
+def _validate_xml_part(name: str, data: bytes) -> None:
+    try:
+        root = ElementTree.fromstring(data)
+    except ElementTree.ParseError as exc:
+        raise PptxXmlPackageError(f"XML part is malformed: {name}") from exc
+    declared = _namespace_map(data)
+    if not _required_prefixes(root).issubset(declared):
+        raise PptxXmlPackageError(f"compatibility namespace is unresolved: {name}")
+
+
+def _validate_relationship_targets(
+    relationship_part: str,
+    data: bytes,
+    members: frozenset[str],
+) -> None:
+    root = ElementTree.fromstring(data)
+    source_directory = posixpath.dirname(_source_part_for_relationships(relationship_part))
+    for relationship in root.iter(RELATIONSHIP_TAG):
+        if relationship.get("TargetMode", "").casefold() == "external":
+            continue
+        target = unquote(relationship.get("Target", "").split("#", 1)[0]).replace("\\", "/")
+        if not target:
+            raise PptxXmlPackageError(f"relationship target is empty: {relationship_part}")
+        resolved = target.lstrip("/") if target.startswith("/") else posixpath.normpath(
+            posixpath.join(source_directory, target),
+        )
+        if resolved not in members:
+            raise PptxXmlPackageError(f"relationship target is missing: {relationship_part}")
+
+
+def _source_part_for_relationships(relationship_part: str) -> str:
+    if relationship_part == "_rels/.rels":
+        return ""
+    marker = "/_rels/"
+    if marker not in relationship_part or not relationship_part.endswith(".rels"):
+        raise PptxXmlPackageError(f"relationship part path is invalid: {relationship_part}")
+    directory, filename = relationship_part.split(marker, 1)
+    return f"{directory}/{filename[:-5]}"
+
+
+def _namespace_map(data: bytes) -> dict[str, str]:
+    namespaces: dict[str, str] = {}
+    try:
+        for _, (prefix, uri) in ElementTree.iterparse(BytesIO(data), events=("start-ns",)):
+            namespaces[prefix] = uri
+    except ElementTree.ParseError as exc:
+        raise PptxXmlPackageError("XML namespace declarations are malformed") from exc
+    return namespaces
+
+
+def _required_prefixes(root: ElementTree.Element) -> set[str]:
+    required: set[str] = set()
+    for choice in root.iter(MC_CHOICE):
+        required.update(choice.get("Requires", "").split())
+    return required
+
+
+def _inject_root_namespaces(data: bytes, missing: dict[str, str]) -> bytes:
+    if not missing:
+        return data
+    declaration = "".join(
+        f" xmlns:{prefix}={quoteattr(uri)}"
+        for prefix, uri in sorted(missing.items())
+    ).encode("utf-8")
+    declaration_end = data.find(b"?>")
+    root_start = data.find(b"<", declaration_end + 2 if declaration_end >= 0 else 0)
+    root_end = data.find(b">", root_start)
+    if root_start < 0 or root_end < 0:
+        raise PptxXmlPackageError("serialized slide has no root element")
+    insertion = root_end - 1 if data[root_end - 1 : root_end] == b"/" else root_end
+    return data[:insertion] + declaration + data[insertion:]

--- a/app/function/pynuo_fuc/pptx_xml_structured.py
+++ b/app/function/pynuo_fuc/pptx_xml_structured.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import copy
+import os
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Final, assert_never
+from xml.etree import ElementTree
+
+from app.translation.pptx_contract import (
+    PptxContractError,
+    PptxUnitTranslation,
+    validate_pptx_translations,
+)
+
+from .pptx_xml_autofit import enable_textbox_autofit_for_paragraph
+from .pptx_xml_manifest import (
+    StructuredParagraphTarget,
+    extract_structured_units_from_pptx,
+    slide_paths,
+    structured_slide_targets,
+)
+from .pptx_xml_package import serialize_slide_xml, validate_pptx_package
+from .pptx_xml_types import (
+    PptxXmlFallbackEligibleError,
+    PptxXmlWriteError,
+    WriteMode,
+)
+
+
+A_NS: Final = "http://schemas.openxmlformats.org/drawingml/2006/main"
+XML_NS: Final = "http://www.w3.org/XML/1998/namespace"
+A_R: Final = f"{{{A_NS}}}r"
+A_T: Final = f"{{{A_NS}}}t"
+A_BR: Final = f"{{{A_NS}}}br"
+A_END_PARA_RPR: Final = f"{{{A_NS}}}endParaRPr"
+XML_SPACE: Final = f"{{{XML_NS}}}space"
+
+
+def write_structured_translated_pptx(
+    input_path: Path | str,
+    output_path: Path | str,
+    translations: tuple[PptxUnitTranslation, ...],
+    bilingual_translation: str,
+) -> str:
+    input_file = Path(input_path)
+    output_file = Path(output_path)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    expected = extract_structured_units_from_pptx(
+        input_file,
+        source_language="",
+        target_language="",
+    )
+    requested_ids = frozenset(item.unit_id for item in translations)
+    expected_subset = tuple(unit for unit in expected if unit.unit_id in requested_ids)
+    validate_pptx_translations(expected_subset, translations)
+
+    with tempfile.NamedTemporaryFile(
+        prefix=f".{output_file.stem}.",
+        suffix=".tmp.pptx",
+        dir=output_file.parent,
+        delete=False,
+    ) as temporary:
+        temporary_path = Path(temporary.name)
+    try:
+        _write_package(
+            input_file,
+            temporary_path,
+            translations,
+            _resolve_write_mode(bilingual_translation),
+        )
+        with zipfile.ZipFile(input_file) as source:
+            expected_members = tuple(source.namelist())
+        validate_pptx_package(temporary_path, expected_members)
+        os.replace(temporary_path, output_file)
+    except (PptxContractError, PptxXmlFallbackEligibleError):
+        temporary_path.unlink(missing_ok=True)
+        raise
+    except (OSError, zipfile.BadZipFile, ElementTree.ParseError) as exc:
+        temporary_path.unlink(missing_ok=True)
+        raise PptxXmlWriteError("could not create a valid translated package") from exc
+    return str(output_file)
+
+
+def _write_package(
+    input_path: Path,
+    output_path: Path,
+    translations: tuple[PptxUnitTranslation, ...],
+    mode: WriteMode,
+) -> None:
+    by_id = {translation.unit_id: translation for translation in translations}
+    written_ids: set[str] = set()
+    with zipfile.ZipFile(input_path) as source, zipfile.ZipFile(
+        output_path,
+        "w",
+        zipfile.ZIP_DEFLATED,
+    ) as target:
+        target.comment = source.comment
+        indexed_slides = {name: index for index, name in enumerate(slide_paths(source))}
+        for item in source.infolist():
+            data = source.read(item.filename)
+            page_index = indexed_slides.get(item.filename)
+            if page_index is not None:
+                data, slide_written = _translated_slide(
+                    data,
+                    item.filename,
+                    page_index,
+                    by_id,
+                    mode,
+                )
+                written_ids.update(slide_written)
+            target.writestr(item, data)
+    if written_ids != set(by_id):
+        raise PptxContractError("writeback_unit_mismatch", "not every translation unit was written")
+
+
+def _translated_slide(
+    slide_data: bytes,
+    slide_path: str,
+    page_index: int,
+    translations: dict[str, PptxUnitTranslation],
+    mode: WriteMode,
+) -> tuple[bytes, set[str]]:
+    root = ElementTree.fromstring(slide_data)
+    targets = structured_slide_targets(
+        root,
+        page_index,
+        slide_path,
+        "",
+        "",
+        (),
+        (),
+    )
+    written: set[str] = set()
+    autofit_targets: dict[ElementTree.Element, ElementTree.Element] = {}
+    for target in targets:
+        translation = translations.get(target.unit.unit_id)
+        if translation is None:
+            continue
+        _apply_translation(target, translation, mode)
+        _ = autofit_targets.setdefault(target.text_body, target.paragraph)
+        written.add(target.unit.unit_id)
+    if not written:
+        return slide_data, written
+    for paragraph in autofit_targets.values():
+        enable_textbox_autofit_for_paragraph(root, paragraph)
+    return serialize_slide_xml(slide_data, root), written
+
+
+def _apply_translation(
+    target: StructuredParagraphTarget,
+    translation: PptxUnitTranslation,
+    mode: WriteMode,
+) -> None:
+    original_content = tuple(copy.deepcopy(node) for node in target.content_nodes)
+    match mode:
+        case WriteMode.TRANSLATION_ONLY:
+            _replace_segments(target, translation)
+        case WriteMode.PARAGRAPH_UP:
+            translated_content = _translated_content(target, translation)
+            _append_content(target.paragraph, translated_content)
+        case WriteMode.PARAGRAPH_DOWN:
+            _replace_segments(target, translation)
+            _append_content(target.paragraph, original_content)
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
+def _replace_segments(
+    target: StructuredParagraphTarget,
+    translation: PptxUnitTranslation,
+) -> None:
+    translated = {item.segment_id: item.target_text for item in translation.segments}
+    for segment_id, text_node in target.segment_nodes:
+        _set_text(text_node, translated[segment_id])
+
+
+def _translated_content(
+    target: StructuredParagraphTarget,
+    translation: PptxUnitTranslation,
+) -> tuple[ElementTree.Element, ...]:
+    segment_iter = iter(translation.segments)
+    translated: list[ElementTree.Element] = []
+    for source in target.content_nodes:
+        clone = copy.deepcopy(source)
+        if source.tag == A_R:
+            segment = next(segment_iter)
+            text_node = clone.find(A_T)
+            if text_node is None:
+                raise PptxContractError("writeback_segment", "cloned run has no text", target.unit.unit_id)
+            _set_text(text_node, segment.target_text)
+        translated.append(clone)
+    return tuple(translated)
+
+
+def _append_content(
+    paragraph: ElementTree.Element,
+    content: tuple[ElementTree.Element, ...],
+) -> None:
+    insert_at = _paragraph_insert_index(paragraph)
+    paragraph.insert(insert_at, ElementTree.Element(A_BR))
+    insert_at += 1
+    for child in content:
+        paragraph.insert(insert_at, child)
+        insert_at += 1
+
+
+def _paragraph_insert_index(paragraph: ElementTree.Element) -> int:
+    for index, child in enumerate(list(paragraph)):
+        if child.tag == A_END_PARA_RPR:
+            return index
+    return len(paragraph)
+
+
+def _set_text(node: ElementTree.Element, text: str) -> None:
+    node.text = text
+    node.set(XML_SPACE, "preserve")
+
+
+def _resolve_write_mode(raw_mode: str) -> WriteMode:
+    aliases = {
+        "paragraph_down": WriteMode.PARAGRAPH_DOWN,
+        "translation_only": WriteMode.TRANSLATION_ONLY,
+        "0": WriteMode.TRANSLATION_ONLY,
+        "paragraph_up": WriteMode.PARAGRAPH_UP,
+        "1": WriteMode.PARAGRAPH_UP,
+        "bilingual": WriteMode.PARAGRAPH_UP,
+        "paragraph": WriteMode.PARAGRAPH_UP,
+    }
+    return aliases.get(raw_mode, WriteMode.PARAGRAPH_UP)
+
+
+__all__ = ["extract_structured_units_from_pptx", "write_structured_translated_pptx"]

--- a/app/function/pynuo_fuc/pptx_xml_translate.py
+++ b/app/function/pynuo_fuc/pptx_xml_translate.py
@@ -1,27 +1,49 @@
 from __future__ import annotations
 
+import os
+import re
 import shutil
+import zipfile
 from collections.abc import Mapping, Sequence
+from xml.etree import ElementTree
+
+from app.translation.pptx_contract import (
+    PPTX_PROVIDER_FIELD,
+    PptxContractError,
+    parse_pptx_response,
+    serialize_pptx_request,
+)
+from app.translation.pptx_contract_types import PptxRequestUnit, PptxUnitTranslation
+from app.translation.providers import ProviderRegistry, default_provider_registry
+from app.translation.types import ProviderError, ProviderRequest
 
 try:
     from .pptx_xml_ops import (
+        extract_structured_units_from_pptx,
         extract_text_boxes_data_from_pptx,
+        write_structured_translated_pptx,
         write_translated_pptx_xml,
     )
     from .pptx_xml_types import (
         PageTranslator,
+        PptxXmlReadError,
+        PptxXmlWriteError,
         ProgressCallback,
         TextBoxData,
         TranslationPageResult,
         XmlTranslationRequest,
     )
 except ImportError:
-    from pptx_xml_ops import (
+    from app.function.pynuo_fuc.pptx_xml_ops import (
+        extract_structured_units_from_pptx,
         extract_text_boxes_data_from_pptx,
+        write_structured_translated_pptx,
         write_translated_pptx_xml,
     )
-    from pptx_xml_types import (
+    from app.function.pynuo_fuc.pptx_xml_types import (
         PageTranslator,
+        PptxXmlReadError,
+        PptxXmlWriteError,
         ProgressCallback,
         TextBoxData,
         TranslationPageResult,
@@ -32,14 +54,28 @@ except ImportError:
 def translate_pptx_with_xml(
     request: XmlTranslationRequest,
     translator: PageTranslator | None = None,
+    *,
+    provider_registry: ProviderRegistry | None = None,
 ) -> str:
-    text_boxes = extract_text_boxes_data_from_pptx(
-        request.input_path,
-        request.selected_page_indices,
-    )
+    engine = os.getenv("PPTX_XML_ENGINE", "structured_v2").strip().lower()
+    if translator is None and engine != "legacy":
+        if engine != "structured_v2":
+            raise PptxContractError("engine_config", "unsupported PPTX XML engine")
+        return _translate_pptx_structured(
+            request,
+            provider_registry or default_provider_registry(),
+        )
+
+    try:
+        text_boxes = extract_text_boxes_data_from_pptx(
+            request.input_path,
+            request.selected_page_indices,
+        )
+    except (OSError, zipfile.BadZipFile, ElementTree.ParseError) as exc:
+        raise PptxXmlReadError("legacy XML extraction failed") from exc
     if not text_boxes:
         request.output_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(request.input_path, request.output_path)
+        _ = shutil.copy2(request.input_path, request.output_path)
         return str(request.output_path)
 
     page_translator = translator or _translate_pages_by_page
@@ -52,13 +88,96 @@ def translate_pptx_with_xml(
         request.stop_words,
         request.custom_translations,
     )
-    return write_translated_pptx_xml(
+    try:
+        return write_translated_pptx_xml(
+            request.input_path,
+            request.output_path,
+            text_boxes,
+            translation_results,
+            request.bilingual_translation,
+        )
+    except (OSError, zipfile.BadZipFile, ElementTree.ParseError) as exc:
+        raise PptxXmlWriteError("legacy XML writeback failed") from exc
+
+
+def _translate_pptx_structured(
+    request: XmlTranslationRequest,
+    registry: ProviderRegistry,
+) -> str:
+    units = extract_structured_units_from_pptx(
+        request.input_path,
+        request.selected_page_indices,
+        source_language=request.source_language,
+        target_language=request.target_language,
+        stop_words=request.stop_words,
+        custom_translations=request.custom_translations,
+    )
+    if not units:
+        request.output_path.parent.mkdir(parents=True, exist_ok=True)
+        _ = shutil.copy2(request.input_path, request.output_path)
+        return str(request.output_path)
+
+    batches = _slide_batches(units)
+    translations: list[PptxUnitTranslation] = []
+    for current, batch in enumerate(batches, 1):
+        translations.extend(_translate_structured_batch(request, registry, batch))
+        if request.progress_callback is not None:
+            request.progress_callback(current, len(batches))
+    return write_structured_translated_pptx(
         request.input_path,
         request.output_path,
-        text_boxes,
-        translation_results,
+        tuple(translations),
         request.bilingual_translation,
     )
+
+
+def _translate_structured_batch(
+    request: XmlTranslationRequest,
+    registry: ProviderRegistry,
+    units: tuple[PptxRequestUnit, ...],
+) -> tuple[PptxUnitTranslation, ...]:
+    provider_request = ProviderRequest.create(
+        text=serialize_pptx_request(units),
+        source_language=request.source_language,
+        target_language=request.target_language,
+        field=PPTX_PROVIDER_FIELD,
+        stop_words=tuple(request.stop_words),
+        custom_translations=dict(request.custom_translations),
+        output_format="structured",
+    )
+    last_contract_error: PptxContractError | None = None
+    for attempt in range(2):
+        try:
+            response = registry.translate(request.model, provider_request)
+        except ProviderError as error:
+            if attempt == 0 and error.retryable:
+                continue
+            raise
+        try:
+            return parse_pptx_response(response.text, units)
+        except PptxContractError as error:
+            last_contract_error = error
+            if attempt == 0:
+                continue
+            raise
+    if last_contract_error is not None:
+        raise last_contract_error
+    raise PptxContractError("provider_failure", "provider did not return a response")
+
+
+def _slide_batches(
+    units: tuple[PptxRequestUnit, ...],
+) -> tuple[tuple[PptxRequestUnit, ...], ...]:
+    batches: list[list[PptxRequestUnit]] = []
+    current_slide = ""
+    for unit in units:
+        match = re.match(r"pptx:slide(\d+):", unit.unit_id)
+        slide = match.group(1) if match is not None else unit.unit_id
+        if slide != current_slide:
+            batches.append([])
+            current_slide = slide
+        batches[-1].append(unit)
+    return tuple(tuple(batch) for batch in batches)
 
 
 def _translate_pages_by_page(
@@ -73,7 +192,7 @@ def _translate_pages_by_page(
     try:
         from .api_translate_uno import translate_pages_by_page
     except ImportError:
-        from api_translate_uno import translate_pages_by_page
+        from app.function.pynuo_fuc.api_translate_uno import translate_pages_by_page
 
     return translate_pages_by_page(
         text_boxes_data,

--- a/app/function/pynuo_fuc/pptx_xml_types.py
+++ b/app/function/pynuo_fuc/pptx_xml_types.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Protocol, TypedDict
 from xml.etree import ElementTree
 
-
 class TextBoxData(TypedDict):
     page_index: int
     box_index: int
@@ -69,3 +68,49 @@ class XmlParagraphTarget:
     runs: tuple[ElementTree.Element, ...]
     text_nodes: tuple[ElementTree.Element, ...]
     text: str
+
+
+class PptxXmlFallbackEligibleError(Exception):
+    """Base class for failures that may use the explicit UNO compatibility lane."""
+
+
+@dataclass(frozen=True, slots=True)
+class PptxXmlReadError(PptxXmlFallbackEligibleError):
+    detail: str
+
+    def __str__(self) -> str:
+        return f"PPTX XML read failed: {self.detail}"
+
+
+@dataclass(frozen=True, slots=True)
+class PptxXmlWriteError(PptxXmlFallbackEligibleError):
+    detail: str
+
+    def __str__(self) -> str:
+        return f"PPTX XML write failed: {self.detail}"
+
+
+@dataclass(frozen=True, slots=True)
+class PptxXmlPackageError(PptxXmlFallbackEligibleError):
+    detail: str
+
+    def __str__(self) -> str:
+        return f"PPTX package validation failed: {self.detail}"
+
+
+@dataclass(frozen=True, slots=True)
+class PptxXmlUnsupportedStructureError(PptxXmlFallbackEligibleError):
+    slide_path: str
+    detail: str
+
+    def __str__(self) -> str:
+        return f"unsupported PPTX text structure in {self.slide_path}: {self.detail}"
+
+
+@dataclass(frozen=True, slots=True)
+class PptxXmlDuplicateShapeIdError(PptxXmlFallbackEligibleError):
+    slide_path: str
+    shape_id: str
+
+    def __str__(self) -> str:
+        return f"duplicate shape ID {self.shape_id} in {self.slide_path}"

--- a/app/function/pynuo_fuc/pyuno_controller.py
+++ b/app/function/pynuo_fuc/pyuno_controller.py
@@ -448,9 +448,8 @@ def _try_translate_pptx_with_xml(presentation_path: str,
 
     try:
         from pathlib import Path
-        from xml.etree import ElementTree
-        import zipfile
         from pptx_xml_translate import XmlTranslationRequest, translate_pptx_with_xml
+        from app.function.pynuo_fuc.pptx_xml_types import PptxXmlFallbackEligibleError
 
         validated_page_indices = _validate_and_normalize_page_indices(select_page)
         original_dir = os.path.dirname(presentation_path)
@@ -472,9 +471,18 @@ def _try_translate_pptx_with_xml(presentation_path: str,
         result_path = translate_pptx_with_xml(request)
         logger.info(f"底层XML翻译完成: {result_path}")
         return result_path
-    except (ImportError, OSError, RuntimeError, ValueError, zipfile.BadZipFile, ElementTree.ParseError) as e:
-        logger.warning(f"底层XML翻译失败，降级到PyUNO流程: {e}", exc_info=True)
-        return None
+    except PptxXmlFallbackEligibleError as e:
+        fallback_enabled = os.getenv("PPTX_XML_RUNTIME_FALLBACK", "0").strip().lower()
+        if fallback_enabled in ("1", "true", "yes", "on"):
+            logger.warning(f"底层XML运行时失败，降级到PyUNO流程: {e}", exc_info=True)
+            return None
+        raise
+    except ImportError:
+        fallback_enabled = os.getenv("PPTX_XML_RUNTIME_FALLBACK", "0").strip().lower()
+        if fallback_enabled in ("1", "true", "yes", "on"):
+            logger.warning("底层XML模块不可用，降级到PyUNO流程", exc_info=True)
+            return None
+        raise
 
 def apply_uno_format_conversion(result_path, original_name, timestamp, temp_dir, original_dir):
     """

--- a/app/static/css/experience.css
+++ b/app/static/css/experience.css
@@ -462,12 +462,17 @@ textarea {
     border-radius: var(--ux-radius-control);
 }
 
+.history-table-wrap {
+    position: relative;
+    isolation: isolate;
+}
+
 .history-table {
-    min-width: 720px;
+    min-width: 620px;
     margin: 0;
     color: var(--ux-text) !important;
     background: var(--ux-panel);
-    table-layout: auto !important;
+    table-layout: fixed !important;
 }
 
 .history-table th {
@@ -481,6 +486,50 @@ textarea {
 .history-table td {
     padding: 12px !important;
     border-bottom-color: var(--ux-border) !important;
+}
+
+.history-file-name {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.history-mobile-meta {
+    display: none;
+}
+
+.history-table th:last-child,
+.history-table td:last-child {
+    position: sticky;
+    right: 0;
+    z-index: 2;
+    width: 112px !important;
+    min-width: 112px;
+    background: var(--ux-panel) !important;
+    box-shadow: -1px 0 var(--ux-border), -10px 0 12px -12px rgba(38, 52, 61, 0.35);
+}
+
+.history-table th:last-child {
+    z-index: 3;
+    background: var(--ux-subtle) !important;
+}
+
+.history-table tr:hover td:last-child {
+    background: #f7fafb !important;
+}
+
+.history-actions {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    min-width: 88px;
+}
+
+.history-actions .action-btn {
+    flex: 0 0 40px;
+    margin: 0 !important;
 }
 
 .history-empty-state td,
@@ -801,6 +850,41 @@ textarea {
     .history-error-state td,
     .history-loading-state td {
         text-align: left !important;
+    }
+
+    .history-table {
+        min-width: 0;
+    }
+
+    .history-table th:nth-child(2),
+    .history-table th:nth-child(3),
+    .history-table th:nth-child(4),
+    .history-table td:nth-child(2),
+    .history-table td:nth-child(3),
+    .history-table td:nth-child(4) {
+        display: none;
+    }
+
+    .history-table th:first-child,
+    .history-table td:first-child {
+        width: auto !important;
+    }
+
+    .history-table th:last-child,
+    .history-table td:last-child {
+        position: static;
+        width: 112px !important;
+        min-width: 112px;
+        box-shadow: none;
+    }
+
+    .history-mobile-meta {
+        display: block;
+        margin-top: 4px;
+        color: var(--ux-muted);
+        font-size: 12px;
+        line-height: 16px;
+        white-space: normal;
     }
 
     .page-selector {

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -11,14 +11,14 @@
             </span>
             <div>
                 <h1 class="auth-card-title">欢迎登录</h1>
-                <p class="auth-card-subtitle">统一账号接入 FrieslandCampina AI 平台</p >
+                <p class="auth-card-subtitle">使用企业 SSO 或本地账号进入 FrieslandCampina AI 平台</p>
             </div>
         </div>
 
         <div class="auth-body">
             {% if sso_enabled %}
             <div class="sso-stack">
-                <a href="/auth/sso/login" class="btn btn-primary sso-btn">
+                <a href="{{ url_for('sso.sso_login') }}" class="btn btn-primary sso-btn">
                     <span class="icon">
                         {% if sso_provider == 'oauth2' %}
                             <i class="fab fa-openid"></i>
@@ -30,36 +30,34 @@
                     </span>
                     <span class="btn-text">使用 SSO 登录</span>
                     <span class="chevron"><i class="fas fa-arrow-right"></i></span>
-                </a >
-                <p class="sso-caption">系统与企业身份平台同步，使用公司账号即可进入系统。</p >
-            </div>
-            {% else %}
-            <div class="sso-stack">
-                <p class="sso-caption">当前未启用统一登录，请联系系统管理员获取访问方式。</p >
+                </a>
+                <p class="sso-caption">系统与企业身份平台同步，使用公司账号即可进入系统。</p>
             </div>
             {% endif %}
 
-            <!-- 临时账号密码登录入口，生产环境下会注释掉 -->
-<!-- {#            <div class="local-login">#}
-{#                <div class="section-divider">#}
-{#                    <span>或使用临时账号登录</span>#}
-{#                </div>#}
-{#                <form class="login-form" method="post" action="/auth/login">#}
-{#                    {% if csrf_token is defined %}#}
-{#                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">#}
-{#                    {% endif %}#}
-{#                    <div class="form-group">#}
-{#                        <label for="username">账号</label>#}
-{#                        <input type="text" id="username" name="username" placeholder="输入账号" required>#}
-{#                    </div>#}
-{#                    <div class="form-group">#}
-{#                        <label for="password">密码</label>#}
-{#                        <input type="password" id="password" name="password" placeholder="输入密码" autocomplete="current-password" required>#}
-{#                    </div>#}
-{#                    <button type="submit" class="btn btn-secondary w-100">账号密码登录</button>#}
-{#                </form>#}
-{#            </div>#}
-{#        </div>#} -->
+            <div class="local-login">
+                {% if sso_enabled %}
+                <div class="divider"><span>或使用账号密码</span></div>
+                {% endif %}
+                <form class="login-form" method="post" action="{{ url_for('auth.login', next=request.args.get('next')) }}">
+                    {% if csrf_token is defined %}
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    {% endif %}
+                    <div class="form-group">
+                        <label for="username">账号</label>
+                        <input type="text" id="username" name="username" placeholder="输入账号" autocomplete="username" autocapitalize="none" spellcheck="false" required autofocus>
+                    </div>
+                    <div class="form-group">
+                        <label for="password">密码</label>
+                        <input type="password" id="password" name="password" placeholder="输入密码" autocomplete="current-password" required>
+                    </div>
+                    <button type="submit" class="btn {% if sso_enabled %}btn-secondary{% else %}btn-primary{% endif %}">
+                        <i class="fas fa-right-to-bracket" aria-hidden="true"></i>
+                        <span>账号密码登录</span>
+                    </button>
+                </form>
+            </div>
+        </div>
 
         <div class="links">
             <span>遇到问题？请联系系统管理员。</span>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{% endblock %}</title>
+    <link rel="icon" href="{{ url_for('static', filename='images/logo.svg') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <!-- 添加Font Awesome图标库 -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -1670,19 +1670,24 @@ async function startTranslation() {
                     
                     return `
                         <tr>
-                            <td title="translated_${escapeHtml(record.filename)}">translated_${escapeHtml(record.filename)}</td>
+                            <td title="translated_${escapeHtml(record.filename)}">
+                                <span class="history-file-name">translated_${escapeHtml(record.filename)}</span>
+                                <span class="history-mobile-meta">${formatDateTime(record.upload_time)} · ${formatFileSize(record.file_size)} · ${statusText}</span>
+                            </td>
                             <td>${formatDateTime(record.upload_time)}</td>
                             <td>${formatFileSize(record.file_size)}</td>
                             <td><span class="status-badge ${statusClass}">${statusText}</span></td>
                             <td>
-                                ${record.file_exists ?
-                                    `<a href="/download/${record.id}" class="action-btn download" title="${currentLanguage === 'en' ? 'Download' : '下载'}" aria-label="${currentLanguage === 'en' ? 'Download' : '下载'}">
-                                        <i class="bi bi-download" aria-hidden="true"></i>
-                                    </a>` : ''
-                                }
-                                <button type="button" class="action-btn delete danger" onclick="deleteFile(${record.id})" title="${currentLanguage === 'en' ? 'Delete' : '删除'}" aria-label="${currentLanguage === 'en' ? 'Delete' : '删除'}">
-                                    <i class="bi bi-trash" aria-hidden="true"></i>
-                                </button>
+                                <div class="history-actions">
+                                    ${record.file_exists ?
+                                        `<a href="/download/${record.id}" class="action-btn download" title="${currentLanguage === 'en' ? 'Download' : '下载'}" aria-label="${currentLanguage === 'en' ? 'Download' : '下载'}">
+                                            <i class="bi bi-download" aria-hidden="true"></i>
+                                        </a>` : ''
+                                    }
+                                    <button type="button" class="action-btn delete danger" onclick="deleteFile(${record.id})" title="${currentLanguage === 'en' ? 'Delete' : '删除'}" aria-label="${currentLanguage === 'en' ? 'Delete' : '删除'}">
+                                        <i class="bi bi-trash" aria-hidden="true"></i>
+                                    </button>
+                                </div>
                             </td>
                         </tr>
                     `;

--- a/app/translation/pptx_contract.py
+++ b/app/translation/pptx_contract.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+from typing import Final, assert_never
+
+from app.translation.pptx_contract_types import (
+    JsonValue,
+    PptxContractError,
+    PptxLineBreakStreamItem,
+    PptxProtectedFieldStreamItem,
+    PptxRequestUnit,
+    PptxSegmentTranslation,
+    PptxSourceStreamItem,
+    PptxTextStreamItem,
+    PptxUnitTranslation,
+)
+from app.translation.pptx_contract_validation import (
+    reconstruct_target,
+    reserved_marker_counts,
+    validate_pptx_translations,
+    validate_request_units,
+    validate_unit_translation,
+)
+
+
+PPTX_PROVIDER_CONTRACT_SCHEMA_VERSION: Final = 2
+PPTX_DOCUMENT_KIND: Final = "pptx_xml"
+PPTX_PROVIDER_FIELD: Final = "pptx_structured_v2"
+
+_ROOT_FIELDS: Final = frozenset(
+    {"provider_contract_schema_version", "document_kind", "translations"},
+)
+_TRANSLATION_FIELDS: Final = frozenset({"unit_id", "target_text", "segments"})
+_SEGMENT_FIELDS: Final = frozenset({"segment_id", "target_text"})
+def serialize_pptx_request(units: tuple[PptxRequestUnit, ...]) -> str:
+    validate_request_units(units)
+    payload = {
+        "provider_contract_schema_version": PPTX_PROVIDER_CONTRACT_SCHEMA_VERSION,
+        "document_kind": PPTX_DOCUMENT_KIND,
+        "units": [_serialize_unit(unit) for unit in units],
+    }
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+def parse_pptx_response(
+    raw: str,
+    expected_units: tuple[PptxRequestUnit, ...],
+) -> tuple[PptxUnitTranslation, ...]:
+    payload = _parse_json_object(_strip_json_fence(raw))
+    _require_exact_fields(payload, _ROOT_FIELDS)
+    if _integer(payload["provider_contract_schema_version"]) != PPTX_PROVIDER_CONTRACT_SCHEMA_VERSION:
+        raise PptxContractError("schema_version", "unsupported provider contract version")
+    if _string(payload["document_kind"]) != PPTX_DOCUMENT_KIND:
+        raise PptxContractError("document_kind", "unexpected document kind")
+    items = _array(payload["translations"])
+    if len(items) != len(expected_units):
+        raise PptxContractError("unit_count", "translation count does not match request")
+
+    translations: list[PptxUnitTranslation] = []
+    for raw_item, unit in zip(items, expected_units, strict=True):
+        item = _mapping(raw_item)
+        _require_exact_fields(item, _TRANSLATION_FIELDS, unit.unit_id)
+        unit_id = _string(item["unit_id"], unit.unit_id)
+        if unit_id != unit.unit_id:
+            raise PptxContractError("unit_order", "unit ID or order differs from request", unit.unit_id)
+        target_text = _string(item["target_text"], unit.unit_id)
+        segments = _parse_segments(item["segments"], unit)
+        translation = PptxUnitTranslation(unit_id, target_text, segments)
+        validate_unit_translation(unit, translation)
+        translations.append(translation)
+    return tuple(translations)
+
+
+def _serialize_unit(unit: PptxRequestUnit) -> dict[str, JsonValue]:
+    return {
+        "unit_id": unit.unit_id,
+        "source_text": unit.source_text,
+        "source_stream": [_serialize_stream_item(item) for item in unit.source_stream],
+        "source_language": unit.source_language,
+        "target_language": unit.target_language,
+        "context": {
+            "previous_text": unit.context.previous_text,
+            "next_text": unit.context.next_text,
+            "title_text": unit.context.title_text,
+        },
+        "layout_hint": {
+            "x_emu": unit.layout_hint.x_emu,
+            "y_emu": unit.layout_hint.y_emu,
+            "width_emu": unit.layout_hint.width_emu,
+            "height_emu": unit.layout_hint.height_emu,
+        },
+        "glossary": [
+            {"source": item.source, "target": item.target}
+            for item in unit.glossary
+        ],
+        "protected_terms": list(unit.protected_terms),
+    }
+
+
+def _serialize_stream_item(item: PptxSourceStreamItem) -> dict[str, JsonValue]:
+    match item:
+        case PptxTextStreamItem():
+            return {
+                "stream_id": item.stream_id,
+                "kind": item.kind,
+                "segment_id": item.segment_id,
+                "source_text": item.source_text,
+            }
+        case PptxLineBreakStreamItem():
+            return {"stream_id": item.stream_id, "kind": item.kind}
+        case PptxProtectedFieldStreamItem():
+            return {"stream_id": item.stream_id, "kind": item.kind, "source_text": item.source_text}
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
+def _parse_segments(raw: JsonValue, unit: PptxRequestUnit) -> tuple[PptxSegmentTranslation, ...]:
+    items = _array(raw, unit.unit_id)
+    expected = unit.text_items
+    if len(items) != len(expected):
+        raise PptxContractError("segment_count", "segment count differs from request", unit.unit_id)
+    parsed: list[PptxSegmentTranslation] = []
+    for raw_item, source in zip(items, expected, strict=True):
+        item = _mapping(raw_item, unit.unit_id)
+        _require_exact_fields(item, _SEGMENT_FIELDS, unit.unit_id)
+        segment_id = _string(item["segment_id"], unit.unit_id)
+        if segment_id != source.segment_id:
+            raise PptxContractError("segment_order", "segment ID or order differs from request", unit.unit_id)
+        parsed.append(PptxSegmentTranslation(segment_id, _string(item["target_text"], unit.unit_id)))
+    return tuple(parsed)
+
+
+def _parse_json_object(raw: str) -> dict[str, JsonValue]:
+    try:
+        value: JsonValue = json.loads(
+            raw,
+            object_pairs_hook=_unique_object,
+            parse_constant=_invalid_constant,
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise PptxContractError("malformed_json", "response is not valid JSON") from exc
+    return _mapping(value)
+
+
+def _unique_object(pairs: list[tuple[str, JsonValue]]) -> dict[str, JsonValue]:
+    result: dict[str, JsonValue] = {}
+    for key, value in pairs:
+        if key in result:
+            raise PptxContractError("duplicate_json_key", "response contains a duplicate key")
+        result[key] = value
+    return result
+
+
+def _invalid_constant(value: str) -> JsonValue:
+    raise PptxContractError("non_finite_number", f"invalid JSON number: {value}")
+
+
+def _mapping(value: JsonValue, unit_id: str = "*") -> dict[str, JsonValue]:
+    if not isinstance(value, dict):
+        raise PptxContractError("schema_mismatch", "expected a JSON object", unit_id)
+    return dict(value)
+
+
+def _array(value: JsonValue, unit_id: str = "*") -> list[JsonValue]:
+    if not isinstance(value, list):
+        raise PptxContractError("schema_mismatch", "expected a JSON array", unit_id)
+    return list(value)
+
+
+def _string(value: JsonValue, unit_id: str = "*") -> str:
+    if not isinstance(value, str):
+        raise PptxContractError("schema_mismatch", "expected a string", unit_id)
+    return value
+
+
+def _integer(value: JsonValue) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise PptxContractError("schema_mismatch", "expected an integer")
+    return value
+
+
+def _require_exact_fields(
+    value: dict[str, JsonValue],
+    expected: frozenset[str],
+    unit_id: str = "*",
+) -> None:
+    if frozenset(value) != expected:
+        raise PptxContractError("schema_mismatch", "missing or unknown response field", unit_id)
+
+
+def _strip_json_fence(raw: str) -> str:
+    stripped = raw.strip()
+    lines = stripped.splitlines()
+    if len(lines) >= 3 and lines[0] == "```json" and lines[-1] == "```":
+        return "\n".join(lines[1:-1])
+    return stripped
+
+
+__all__ = [
+    "PPTX_DOCUMENT_KIND",
+    "PPTX_PROVIDER_CONTRACT_SCHEMA_VERSION",
+    "PPTX_PROVIDER_FIELD",
+    "PptxContractError",
+    "PptxSegmentTranslation",
+    "PptxUnitTranslation",
+    "parse_pptx_response",
+    "reconstruct_target",
+    "reserved_marker_counts",
+    "serialize_pptx_request",
+    "validate_pptx_translations",
+]

--- a/app/translation/pptx_contract_types.py
+++ b/app/translation/pptx_contract_types.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, TypeAlias
+
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+
+
+@dataclass(frozen=True, slots=True)
+class PptxContractError(Exception):
+    code: str
+    detail: str
+    unit_id: str = "*"
+
+    def __str__(self) -> str:
+        return f"PPTX translation contract {self.code} for {self.unit_id}: {self.detail}"
+
+
+@dataclass(frozen=True, slots=True)
+class PptxContext:
+    previous_text: str = ""
+    next_text: str = ""
+    title_text: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class PptxLayoutHint:
+    x_emu: int | None = None
+    y_emu: int | None = None
+    width_emu: int | None = None
+    height_emu: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PptxGlossaryEntry:
+    source: str
+    target: str
+
+
+@dataclass(frozen=True, slots=True)
+class PptxTextStreamItem:
+    stream_id: str
+    segment_id: str
+    source_text: str
+    kind: Literal["text"] = field(init=False, default="text")
+
+
+@dataclass(frozen=True, slots=True)
+class PptxLineBreakStreamItem:
+    stream_id: str
+    kind: Literal["line_break"] = field(init=False, default="line_break")
+
+
+@dataclass(frozen=True, slots=True)
+class PptxProtectedFieldStreamItem:
+    stream_id: str
+    source_text: str
+    kind: Literal["protected_field"] = field(init=False, default="protected_field")
+
+
+PptxSourceStreamItem: TypeAlias = (
+    PptxTextStreamItem | PptxLineBreakStreamItem | PptxProtectedFieldStreamItem
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PptxRequestUnit:
+    unit_id: str
+    source_text: str
+    source_stream: tuple[PptxSourceStreamItem, ...]
+    source_language: str
+    target_language: str
+    context: PptxContext = PptxContext()
+    layout_hint: PptxLayoutHint = PptxLayoutHint()
+    glossary: tuple[PptxGlossaryEntry, ...] = ()
+    protected_terms: tuple[str, ...] = ()
+
+    @property
+    def text_items(self) -> tuple[PptxTextStreamItem, ...]:
+        return tuple(item for item in self.source_stream if isinstance(item, PptxTextStreamItem))
+
+
+@dataclass(frozen=True, slots=True)
+class PptxSegmentTranslation:
+    segment_id: str
+    target_text: str
+
+
+@dataclass(frozen=True, slots=True)
+class PptxUnitTranslation:
+    unit_id: str
+    target_text: str
+    segments: tuple[PptxSegmentTranslation, ...]

--- a/app/translation/pptx_contract_validation.py
+++ b/app/translation/pptx_contract_validation.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections import Counter
+from typing import Final, assert_never
+
+from app.translation.pptx_contract_types import (
+    PptxContractError,
+    PptxLineBreakStreamItem,
+    PptxProtectedFieldStreamItem,
+    PptxRequestUnit,
+    PptxSegmentTranslation,
+    PptxTextStreamItem,
+    PptxUnitTranslation,
+)
+
+
+_RESERVED_MARKER_RE: Final = re.compile(
+    r"\[\s*(?P<marker>b\s*l\s*o\s*c\s*k|块)\s*\]",
+    re.IGNORECASE,
+)
+
+
+def validate_request_units(units: tuple[PptxRequestUnit, ...]) -> None:
+    unit_ids = [unit.unit_id for unit in units]
+    if len(unit_ids) != len(set(unit_ids)):
+        raise PptxContractError("duplicate_unit_id", "request contains duplicate unit IDs")
+    for unit in units:
+        stream_ids = [item.stream_id for item in unit.source_stream]
+        segment_ids = [item.segment_id for item in unit.text_items]
+        if len(stream_ids) != len(set(stream_ids)) or len(segment_ids) != len(set(segment_ids)):
+            raise PptxContractError("duplicate_stream_id", "request contains duplicate stream IDs", unit.unit_id)
+        if not segment_ids:
+            raise PptxContractError("missing_segment", "request unit has no text segment", unit.unit_id)
+        if unit.layout_hint.width_emu is not None and unit.layout_hint.width_emu <= 0:
+            raise PptxContractError("layout_hint", "width must be positive", unit.unit_id)
+        if unit.layout_hint.height_emu is not None and unit.layout_hint.height_emu <= 0:
+            raise PptxContractError("layout_hint", "height must be positive", unit.unit_id)
+
+
+def validate_pptx_translations(
+    expected_units: tuple[PptxRequestUnit, ...],
+    translations: tuple[PptxUnitTranslation, ...],
+) -> None:
+    if len(expected_units) != len(translations):
+        raise PptxContractError("unit_count", "translation count does not match request")
+    for unit, translation in zip(expected_units, translations, strict=True):
+        if translation.unit_id != unit.unit_id:
+            raise PptxContractError("unit_order", "unit ID or order differs from request", unit.unit_id)
+        expected_ids = tuple(item.segment_id for item in unit.text_items)
+        actual_ids = tuple(item.segment_id for item in translation.segments)
+        if expected_ids != actual_ids:
+            raise PptxContractError("segment_order", "segment IDs or order differ from request", unit.unit_id)
+        validate_unit_translation(unit, translation)
+
+
+def validate_unit_translation(
+    unit: PptxRequestUnit,
+    translation: PptxUnitTranslation,
+) -> None:
+    if unit.source_text.strip() and not translation.target_text.strip():
+        raise PptxContractError("blank_target", "nonblank source has blank target", unit.unit_id)
+    reconstructed = reconstruct_target(unit, translation.segments)
+    if _consistency_text(reconstructed) != _consistency_text(translation.target_text):
+        raise PptxContractError("target_mismatch", "target text differs from translated stream", unit.unit_id)
+    if reserved_marker_counts(unit.source_text) != reserved_marker_counts(translation.target_text):
+        raise PptxContractError("reserved_marker_added", "reserved marker provenance differs", unit.unit_id)
+    for source, target in zip(unit.text_items, translation.segments, strict=True):
+        if reserved_marker_counts(source.source_text) != reserved_marker_counts(target.target_text):
+            raise PptxContractError("reserved_marker_added", "segment marker provenance differs", unit.unit_id)
+
+
+def reserved_marker_counts(text: str) -> Counter[str]:
+    normalized = unicodedata.normalize("NFKC", text)
+    counts: Counter[str] = Counter()
+    for match in _RESERVED_MARKER_RE.finditer(normalized):
+        marker = "".join(match.group("marker").split()).casefold()
+        counts[marker] += 1
+    return counts
+
+
+def reconstruct_target(
+    unit: PptxRequestUnit,
+    segments: tuple[PptxSegmentTranslation, ...],
+) -> str:
+    by_id = {segment.segment_id: segment.target_text for segment in segments}
+    parts: list[str] = []
+    for item in unit.source_stream:
+        match item:
+            case PptxTextStreamItem():
+                parts.append(by_id[item.segment_id])
+            case PptxLineBreakStreamItem():
+                parts.append("\n")
+            case PptxProtectedFieldStreamItem():
+                parts.append(item.source_text)
+            case _ as unreachable:
+                assert_never(unreachable)
+    return "".join(parts)
+
+
+def _consistency_text(text: str) -> str:
+    return unicodedata.normalize("NFC", text).replace("\r\n", "\n").replace("\r", "\n")

--- a/app/translation/providers.py
+++ b/app/translation/providers.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 from dataclasses import dataclass
 from time import perf_counter
 from typing import Final, Protocol
 
+from app.translation.pptx_contract_types import JsonValue
 from app.translation.types import ProviderError, ProviderName, ProviderRequest, ProviderResult, TranslationProvider
 from app.translation.metrics import current_correlation, current_metrics, log_translation_event
 
@@ -178,15 +180,47 @@ class _RequestsRemoteTransport:
             raise TimeoutError("remote provider timed out") from exc
         except (requests.RequestException, ValueError) as exc:
             raise RemoteProviderResponseError("remote provider returned an invalid response") from exc
+        if not isinstance(body, dict):
+            raise RemoteProviderResponseError("remote provider returned an invalid response")
         if body.get("code") != 200:
             raise RemoteProviderResponseError(f"remote provider status {body.get('code')}")
-        data = body.get("data", "")
-        if isinstance(data, dict):
-            return str(data.get("translated_json") or data.get("result") or data.get("content") or "")
-        return str(data)
+        return _remote_data_text(body.get("data", ""))
+
+
+def _remote_data_text(data: JsonValue) -> str:
+    if isinstance(data, str):
+        return data
+    if isinstance(data, dict):
+        for key in ("translated_json", "result", "content", "output"):
+            candidate = data.get(key)
+            if candidate is not None and candidate != "":
+                return _remote_data_text(candidate)
+        return json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    return _json_or_text(data)
+
+
+def _json_or_text(value: JsonValue) -> str:
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    return str(value)
 
 
 def _semantic_system_prompt(request: ProviderRequest) -> str:
+    if request.field == "pptx_structured_v2":
+        return "\n".join(
+            (
+                f"Translate PPTX text from {request.source_language} to {request.target_language}.",
+                "The user message is one JSON object with provider_contract_schema_version 2 and document_kind pptx_xml.",
+                "Translate each unit as one semantic paragraph while preserving its unit_id and input order.",
+                "Return exactly one JSON object with provider_contract_schema_version, document_kind, and translations.",
+                "Each translation must contain exactly unit_id, target_text, and an ordered segments array.",
+                "Each segment must contain exactly segment_id and target_text, preserving every text segment ID and order.",
+                "Keep line_break controls as newlines in target_text and copy protected_field text unchanged.",
+                "Do not return source_stream controls, unknown fields, prose, comments, or Markdown fences.",
+                f"Keep these terms unchanged: {_quoted_words(request.stop_words)}.",
+                f"Apply this glossary: {_quoted_translations(request.custom_translations)}.",
+            ),
+        )
     if request.output_format == "plain":
         return "\n".join(
             (

--- a/docs/PROJECT_ARCHITECTURE_AND_REQUIREMENTS.md
+++ b/docs/PROJECT_ARCHITECTURE_AND_REQUIREMENTS.md
@@ -144,10 +144,10 @@ V2 任务系统以 MySQL `translation_jobs` 为状态事实源，Worker 通过�
 | `translation_only` | 已实现 | 仅保留译文，替换原文本节点。 |
 | `paragraph_up` | 已实现 | 保留原文，在同一段落换行后追加译文。 |
 | `paragraph_down` | 已实现 | 先写译文，再换行追加原文。 |
-| 保留文本片段格式 | 已实现但有限制 | 翻译返回的 `[block]` 片段数匹配时克隆原 run 样式；数量不匹配时会合并为单一片段。 |
+| 保留文本片段格式 | 已实现 | `.pptx` 默认使用稳定 unit/segment ID 回写到原 `a:r/a:t`，不再把 `[block]` 作为内部协议；字段、换行、超链接关系和 run 样式保持不变。 |
 | 文本框自动适配 | 已实现并有测试 | 写入译文时移除 `noAutofit/spAutoFit`，写入 `a:normAutofit`，由 Office/LibreOffice 按框缩小文字。 |
 | XML 优先、布局保真 | 已实现 | 直接复制 PPTX ZIP 并只替换目标 slide XML；成功后立即返回，不再进入旧布局调整。 |
-| LibreOffice/PyUNO 降级 | 有条件可用 | XML 路径失败时使用 PPTX/ODP/UNO 流程，需要本机 LibreOffice。 |
+| LibreOffice/PyUNO 降级 | 有条件可用 | 仅类型化 ZIP/XML/包/结构运行时错误可在 `PPTX_XML_RUNTIME_FALLBACK=1` 时进入 UNO；Provider、协议和标记错误不会降级。 |
 | `.ppt` 兼容 | 部分实现 | XML 路径只支持 `.pptx`；`.ppt` 依赖 UNO/转换路径，未有自动化验证。 |
 | PPT 图片 OCR 与翻译 | 部分实现 | 可提取图片、调用 Qwen OCR/翻译并向幻灯片追加文本；依赖密钥，缺端到端测试。 |
 | 队列、进度、重试、取消 | 已实现 | V2 使用数据库任务账本、租约、版本校验和统一状态投影；旧 `EnhancedTranslationQueue` 作为 `legacy` 回滚路径保留。自动恢复默认关闭。 |

--- a/docs/TRANSLATION_ARCHITECTURE.md
+++ b/docs/TRANSLATION_ARCHITECTURE.md
@@ -177,3 +177,42 @@ python tools/qa/benchmark_translation_architecture.py --root D:\project\FCIAI2.0
 ```
 
 真实 PPT 验收命令见项目 `README.md`。该命令使用确定性 Provider 和源文件副本，不调用真实模型，也不修改用户原文件。
+
+## 10. PPTX 结构化翻译 V2
+
+`.pptx` 默认使用 `PPTX_XML_ENGINE=structured_v2`。旧页面协议仍可通过
+`PPTX_XML_ENGINE=legacy` 显式回滚，但两条 XML 写回路径都会执行命名空间保留、
+ZIP/XML/关系目标检查和原子发布。
+
+V2 链路如下：
+
+```text
+slide XML
+  -> 物理 slide + shape id + text-body ordinal + paragraph ordinal 稳定 ID
+  -> paragraph source_stream（text / line_break / protected_field）
+  -> provider_contract_schema_version=2 JSON
+  -> 严格校验 unit/segment ID、顺序、数量、目标重建和保留标记来源
+  -> 精确写回原 a:r/a:t
+  -> changed text body 设置单一 a:normAutofit
+  -> 临时 PPTX 静态审计
+  -> os.replace 原子发布
+```
+
+结构校验不受 `TRANSLATION_QUALITY_MODE` 影响。Provider 返回缺失字段、未知字段、
+错序 ID、错段数、空译文，或凭空新增 `[block]` / `[块]` 及其规范化变体时，当前
+批次只重试一次；第二次仍失败则任务失败，不写出部分文件，也不会切换模型或进入
+旧提示词。
+
+运行时降级由独立开关控制：
+
+```dotenv
+PPTX_XML_ENGINE=structured_v2
+PPTX_XML_RUNTIME_FALLBACK=0
+```
+
+只有 ZIP、XML、写入、包完整性、重复 shape ID 和不支持的文本结构等类型化运行时
+错误，才可在 `PPTX_XML_RUNTIME_FALLBACK=1` 时进入 UNO 兼容路径。Provider、协议
+和保留标记错误始终失败关闭。
+
+当前范围覆盖幻灯片正文和表格单元格中已有的 `txBody`。图表、SmartArt、备注、
+母版、嵌入对象等非 slide XML 正文不翻译，但其 ZIP 成员保持原样。

--- a/tests/test_pptx_structured_v2.py
+++ b/tests/test_pptx_structured_v2.py
@@ -1,0 +1,631 @@
+"""End-to-end PPTX V2 acceptance tests.
+
+# noqa: SIZE_OK - contract, writeback, and fallback acceptance stays self-contained.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from dataclasses import dataclass, field
+from io import BytesIO
+from pathlib import Path
+from types import ModuleType
+from xml.etree import ElementTree
+
+import pytest
+
+from app.function.pynuo_fuc.pptx_xml_ops import (
+    extract_structured_units_from_pptx,
+    extract_text_boxes_data_from_pptx,
+    write_structured_translated_pptx,
+    write_translated_pptx_xml,
+)
+from app.function.pynuo_fuc.pptx_xml_translate import translate_pptx_with_xml
+from app.function.pynuo_fuc.pptx_xml_types import (
+    PptxXmlDuplicateShapeIdError,
+    PptxXmlPackageError,
+    XmlTranslationRequest,
+)
+from app.translation.pptx_contract import (
+    PPTX_DOCUMENT_KIND,
+    PPTX_PROVIDER_CONTRACT_SCHEMA_VERSION,
+    PptxContractError,
+    PptxSegmentTranslation,
+    PptxUnitTranslation,
+    parse_pptx_response,
+    serialize_pptx_request,
+)
+from app.translation.pptx_contract_types import JsonValue
+from app.translation.providers import ProviderRegistry, QwenProvider
+from app.translation.types import ProviderName, ProviderRequest, ProviderResult
+
+
+A_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
+P_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
+MC_NS = "http://schemas.openxmlformats.org/markup-compatibility/2006"
+P14_NS = "http://schemas.microsoft.com/office/powerpoint/2010/main"
+NS = {"a": A_NS, "p": P_NS, "mc": MC_NS}
+
+
+@dataclass(frozen=True, slots=True)
+class ContractProvider:
+    responses: list[str] = field(default_factory=list)
+    requests: list[ProviderRequest] = field(default_factory=list)
+
+    @property
+    def name(self) -> ProviderName:
+        return "qwen"
+
+    def translate(self, request: ProviderRequest) -> ProviderResult:
+        self.requests.append(request)
+        if self.responses:
+            response = self.responses.pop(0)
+        else:
+            payload = json.loads(request.text)
+            translations = []
+            for unit in payload["units"]:
+                segments = [
+                    {"segment_id": item["segment_id"], "target_text": f"T:{item['source_text']}"}
+                    for item in unit["source_stream"]
+                    if item["kind"] == "text"
+                ]
+                target = _reconstruct_target(unit["source_stream"], segments)
+                translations.append(
+                    {"unit_id": unit["unit_id"], "target_text": target, "segments": segments},
+                )
+            response = json.dumps(
+                {
+                    "provider_contract_schema_version": PPTX_PROVIDER_CONTRACT_SCHEMA_VERSION,
+                    "document_kind": PPTX_DOCUMENT_KIND,
+                    "translations": translations,
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        return ProviderResult(response, "qwen", "fake-qwen")
+
+
+@dataclass(frozen=True, slots=True)
+class PromptTransport:
+    calls: list[tuple[str, str, str, float]] = field(default_factory=list)
+
+    def complete(self, model: str, system: str, user: str, timeout_seconds: float) -> str:
+        self.calls.append((model, system, user, timeout_seconds))
+        return "{}"
+
+
+def test_structured_manifest_uses_stable_ids_and_explicit_control_stream(tmp_path: Path) -> None:
+    source = tmp_path / "source.pptx"
+    _write_minimal_pptx(source, _structured_slide_xml())
+
+    units = extract_structured_units_from_pptx(
+        source,
+        source_language="English",
+        target_language="Chinese",
+        stop_words=("HMO",),
+        custom_translations={"milk": "乳汁"},
+    )
+
+    assert len(units) == 1
+    unit = units[0]
+    assert unit.unit_id == "pptx:slide1:shapeId7:tbOrdinal0:p0"
+    assert unit.source_text == "Hello\n1world"
+    assert [item.kind for item in unit.source_stream] == [
+        "text",
+        "line_break",
+        "protected_field",
+        "text",
+    ]
+    assert [item.segment_id for item in unit.text_items] == [
+        f"{unit.unit_id}:segment0",
+        f"{unit.unit_id}:segment3",
+    ]
+    assert unit.protected_terms == ("HMO",)
+    assert unit.glossary[0].source == "milk"
+
+
+def test_table_cells_under_one_graphic_frame_get_distinct_text_body_ids(tmp_path: Path) -> None:
+    source = tmp_path / "table.pptx"
+    _write_minimal_pptx(source, _table_slide_xml())
+
+    units = extract_structured_units_from_pptx(
+        source,
+        source_language="English",
+        target_language="Chinese",
+    )
+
+    assert [unit.unit_id for unit in units] == [
+        "pptx:slide1:shapeId9:tbOrdinal0:p0",
+        "pptx:slide1:shapeId9:tbOrdinal1:p0",
+    ]
+
+
+def test_duplicate_shape_identity_is_a_typed_runtime_failure(tmp_path: Path) -> None:
+    source = tmp_path / "duplicate.pptx"
+    duplicate_shapes = _simple_shape_xml(7, "First") + _simple_shape_xml(7, "Second")
+    slide = (
+        "<?xml version='1.0' encoding='UTF-8' standalone='yes'?>"
+        f"<p:sld xmlns:a='{A_NS}' xmlns:p='{P_NS}'><p:cSld><p:spTree>"
+        f"{duplicate_shapes}</p:spTree></p:cSld></p:sld>"
+    )
+    _write_minimal_pptx(source, slide)
+
+    with pytest.raises(PptxXmlDuplicateShapeIdError):
+        extract_structured_units_from_pptx(
+            source,
+            source_language="English",
+            target_language="Chinese",
+        )
+
+
+def test_provider_contract_is_exact_json_and_contains_no_internal_sentinel(tmp_path: Path) -> None:
+    source = tmp_path / "source.pptx"
+    _write_minimal_pptx(source, _structured_slide_xml())
+    units = extract_structured_units_from_pptx(
+        source,
+        source_language="English",
+        target_language="Chinese",
+    )
+
+    raw = serialize_pptx_request(units)
+    payload = json.loads(raw)
+
+    assert list(payload) == [
+        "provider_contract_schema_version",
+        "document_kind",
+        "units",
+    ]
+    assert payload["provider_contract_schema_version"] == 2
+    assert payload["document_kind"] == "pptx_xml"
+    assert "[block]" not in raw.casefold()
+    assert "[块]" not in raw
+    assert set(payload["units"][0]) == {
+        "unit_id",
+        "source_text",
+        "source_stream",
+        "source_language",
+        "target_language",
+        "context",
+        "layout_hint",
+        "glossary",
+        "protected_terms",
+    }
+
+
+def test_qwen_v2_prompt_uses_ids_and_never_teaches_the_legacy_sentinel() -> None:
+    transport = PromptTransport()
+    request = ProviderRequest.create(
+        text='{"provider_contract_schema_version":2}',
+        source_language="English",
+        target_language="Chinese",
+        field="pptx_structured_v2",
+    )
+
+    QwenProvider(transport).translate(request)
+
+    system = transport.calls[0][1]
+    assert "unit_id" in system and "segment_id" in system
+    assert "source_stream" in system and "protected_field" in system
+    assert "[block]" not in system.casefold()
+    assert "[块]" not in system
+
+
+@pytest.mark.parametrize("leaked_marker", ("[块]", "［块］", "[ B L O C K ]"))
+def test_response_parser_rejects_added_reserved_marker_even_when_quality_is_off(
+    tmp_path: Path,
+    leaked_marker: str,
+) -> None:
+    source = tmp_path / "source.pptx"
+    _write_minimal_pptx(source, _simple_slide_xml("Milk"))
+    units = extract_structured_units_from_pptx(
+        source,
+        source_language="English",
+        target_language="Chinese",
+    )
+    unit = units[0]
+    translated = f"母乳{leaked_marker}"
+    raw = _response_json(
+        unit.unit_id,
+        translated,
+        [(unit.text_items[0].segment_id, translated)],
+    )
+
+    with pytest.raises(PptxContractError) as raised:
+        parse_pptx_response(raw, units)
+
+    assert raised.value.code == "reserved_marker_added"
+
+
+def test_legacy_writer_also_rejects_translated_marker_leak(tmp_path: Path) -> None:
+    source = tmp_path / "source.pptx"
+    output = tmp_path / "translated.pptx"
+    _write_minimal_pptx(source, _simple_slide_xml("Milk"))
+    text_boxes = extract_text_boxes_data_from_pptx(source)
+
+    with pytest.raises(PptxContractError) as raised:
+        write_translated_pptx_xml(
+            source,
+            output,
+            text_boxes,
+            {0: {"translated_fragments": {"1_1": ["母乳[块]"]}}},
+            "translation_only",
+        )
+
+    assert raised.value.code == "reserved_marker_added"
+    assert not output.exists()
+
+
+def test_source_authored_reserved_literal_is_allowed_only_when_preserved(tmp_path: Path) -> None:
+    source = tmp_path / "source.pptx"
+    _write_minimal_pptx(source, _simple_slide_xml("Use [block] literally"))
+    units = extract_structured_units_from_pptx(
+        source,
+        source_language="English",
+        target_language="Chinese",
+    )
+    unit = units[0]
+    target = "按字面使用 [block]"
+    response = _response_json(
+        unit.unit_id,
+        target,
+        [(unit.text_items[0].segment_id, target)],
+    )
+
+    parsed = parse_pptx_response(response, units)
+
+    assert parsed[0].target_text == target
+
+
+def test_response_parser_rejects_unknown_fields_and_segment_order(tmp_path: Path) -> None:
+    source = tmp_path / "source.pptx"
+    _write_minimal_pptx(source, _simple_slide_xml("Hello", "world"))
+    units = extract_structured_units_from_pptx(
+        source,
+        source_language="English",
+        target_language="Chinese",
+    )
+    unit = units[0]
+    payload = json.loads(
+        _response_json(
+            unit.unit_id,
+            "世界你好",
+            [
+                (unit.text_items[1].segment_id, "世界"),
+                (unit.text_items[0].segment_id, "你好"),
+            ],
+        ),
+    )
+    payload["unexpected"] = True
+
+    with pytest.raises(PptxContractError) as raised:
+        parse_pptx_response(json.dumps(payload, ensure_ascii=False), units)
+
+    assert raised.value.code == "schema_mismatch"
+
+
+def test_structured_writer_preserves_runs_fields_breaks_and_required_prefix(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.pptx"
+    output = tmp_path / "translated.pptx"
+    _write_minimal_pptx(source, _structured_slide_xml(required_prefix_only=True))
+    units = extract_structured_units_from_pptx(
+        source,
+        source_language="English",
+        target_language="Chinese",
+    )
+    unit = units[0]
+    translations = (
+        PptxUnitTranslation(
+            unit_id=unit.unit_id,
+            target_text="你好\n1世界",
+            segments=(
+                PptxSegmentTranslation(unit.text_items[0].segment_id, "你好"),
+                PptxSegmentTranslation(unit.text_items[1].segment_id, "世界"),
+            ),
+        ),
+    )
+
+    write_structured_translated_pptx(source, output, translations, "translation_only")
+
+    with zipfile.ZipFile(output) as archive:
+        assert archive.testzip() is None
+        slide_data = archive.read("ppt/slides/slide1.xml")
+    root = ElementTree.fromstring(slide_data)
+    assert [node.text or "" for node in root.findall(".//a:r/a:t", NS)] == ["你好", "世界"]
+    assert root.find(".//a:fld/a:t", NS).text == "1"
+    assert len(root.findall(".//a:br", NS)) == 1
+    assert root.find(".//a:rPr[@sz='2400']", NS) is not None
+    assert root.find(".//a:bodyPr/a:normAutofit", NS) is not None
+    assert "p14" in _declared_prefixes(slide_data)
+
+
+def test_default_xml_engine_retries_invalid_contract_once_and_never_publishes_marker(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.pptx"
+    output = tmp_path / "translated.pptx"
+    _write_minimal_pptx(source, _simple_slide_xml("Milk"))
+    units = extract_structured_units_from_pptx(
+        source,
+        source_language="English",
+        target_language="Chinese",
+    )
+    unit = units[0]
+    provider = ContractProvider(
+        responses=[
+            _response_json(
+                unit.unit_id,
+                "母乳[块]",
+                [(unit.text_items[0].segment_id, "母乳[块]")],
+            ),
+            _response_json(
+                unit.unit_id,
+                "母乳",
+                [(unit.text_items[0].segment_id, "母乳")],
+            ),
+        ],
+    )
+    request = XmlTranslationRequest(
+        input_path=source,
+        output_path=output,
+        selected_page_indices=None,
+        source_language="English",
+        target_language="Chinese",
+        model="qwen",
+        stop_words=(),
+        custom_translations={},
+        bilingual_translation="translation_only",
+        progress_callback=None,
+    )
+
+    result = translate_pptx_with_xml(
+        request,
+        provider_registry=ProviderRegistry((provider,)),
+    )
+
+    assert result == str(output)
+    assert len(provider.requests) == 2
+    assert all(item.field == "pptx_structured_v2" for item in provider.requests)
+    with zipfile.ZipFile(output) as archive:
+        slide_data = archive.read("ppt/slides/slide1.xml")
+    assert "[块]" not in slide_data.decode("utf-8")
+    assert [node.text for node in ElementTree.fromstring(slide_data).findall(".//a:t", NS)] == ["母乳"]
+
+
+def test_selected_page_translation_preserves_unselected_slide_bytes(tmp_path: Path) -> None:
+    source = tmp_path / "source.pptx"
+    output = tmp_path / "translated.pptx"
+    _write_minimal_pptx(
+        source,
+        _simple_slide_xml("First"),
+        _simple_slide_xml("Second"),
+    )
+    request = XmlTranslationRequest(
+        input_path=source,
+        output_path=output,
+        selected_page_indices=(0,),
+        source_language="English",
+        target_language="Chinese",
+        model="qwen",
+        stop_words=(),
+        custom_translations={},
+        bilingual_translation="translation_only",
+        progress_callback=None,
+    )
+    provider = ContractProvider()
+
+    translate_pptx_with_xml(request, provider_registry=ProviderRegistry((provider,)))
+
+    with zipfile.ZipFile(source) as original, zipfile.ZipFile(output) as translated:
+        assert translated.read("ppt/slides/slide2.xml") == original.read("ppt/slides/slide2.xml")
+        assert translated.read("ppt/slides/slide1.xml") != original.read("ppt/slides/slide1.xml")
+    assert len(provider.requests) == 1
+
+
+def test_default_xml_engine_fails_closed_after_second_invalid_response(tmp_path: Path) -> None:
+    source = tmp_path / "source.pptx"
+    output = tmp_path / "translated.pptx"
+    _write_minimal_pptx(source, _simple_slide_xml("Milk"))
+    units = extract_structured_units_from_pptx(
+        source,
+        source_language="English",
+        target_language="Chinese",
+    )
+    unit = units[0]
+    invalid = _response_json(
+        unit.unit_id,
+        "母乳[块]",
+        [(unit.text_items[0].segment_id, "母乳[块]")],
+    )
+    provider = ContractProvider(responses=[invalid, invalid])
+    request = XmlTranslationRequest(
+        input_path=source,
+        output_path=output,
+        selected_page_indices=None,
+        source_language="English",
+        target_language="Chinese",
+        model="qwen",
+        stop_words=(),
+        custom_translations={},
+        bilingual_translation="translation_only",
+        progress_callback=None,
+    )
+
+    with pytest.raises(PptxContractError):
+        translate_pptx_with_xml(request, provider_registry=ProviderRegistry((provider,)))
+
+    assert len(provider.requests) == 2
+    assert not output.exists()
+
+
+def test_provider_contract_failure_never_enters_uno_runtime_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.function.pynuo_fuc import pyuno_controller as controller
+    import pptx_xml_translate as xml_translate_module
+
+    def fail_contract(_request: XmlTranslationRequest) -> str:
+        raise PptxContractError("reserved_marker_added", "rejected")
+
+    monkeypatch.setenv("PPTX_XML_RUNTIME_FALLBACK", "1")
+    monkeypatch.setattr(xml_translate_module, "translate_pptx_with_xml", fail_contract)
+
+    with pytest.raises(PptxContractError):
+        _try_controller_xml_path(controller, tmp_path / "deck.pptx")
+
+
+def test_typed_package_failure_uses_uno_fallback_only_when_explicitly_enabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.function.pynuo_fuc import pyuno_controller as controller
+    import pptx_xml_translate as xml_translate_module
+
+    def fail_package(_request: XmlTranslationRequest) -> str:
+        raise PptxXmlPackageError("invalid package")
+
+    monkeypatch.setattr(xml_translate_module, "translate_pptx_with_xml", fail_package)
+    monkeypatch.setenv("PPTX_XML_RUNTIME_FALLBACK", "0")
+    with pytest.raises(PptxXmlPackageError):
+        _try_controller_xml_path(controller, tmp_path / "deck.pptx")
+
+    monkeypatch.setenv("PPTX_XML_RUNTIME_FALLBACK", "1")
+    assert _try_controller_xml_path(controller, tmp_path / "deck.pptx") is None
+
+
+def _response_json(
+    unit_id: str,
+    target_text: str,
+    segments: list[tuple[str, str]],
+) -> str:
+    return json.dumps(
+        {
+            "provider_contract_schema_version": 2,
+            "document_kind": "pptx_xml",
+            "translations": [
+                {
+                    "unit_id": unit_id,
+                    "target_text": target_text,
+                    "segments": [
+                        {"segment_id": segment_id, "target_text": text}
+                        for segment_id, text in segments
+                    ],
+                },
+            ],
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _try_controller_xml_path(controller: ModuleType, path: Path) -> str | None:
+    translate = getattr(controller, "_try_translate_pptx_with_xml")
+    result: str | None = translate(
+        str(path),
+        [],
+        {},
+        [],
+        "English",
+        "Chinese",
+        "translation_only",
+        None,
+        "qwen",
+    )
+    return result
+
+
+def _reconstruct_target(
+    source_stream: list[dict[str, JsonValue]],
+    segments: list[dict[str, str]],
+) -> str:
+    translated = {item["segment_id"]: item["target_text"] for item in segments}
+    parts: list[str] = []
+    for item in source_stream:
+        kind = item["kind"]
+        if kind == "text":
+            parts.append(translated[str(item["segment_id"])])
+        elif kind == "line_break":
+            parts.append("\n")
+        else:
+            parts.append(str(item["source_text"]))
+    return "".join(parts)
+
+
+def _write_minimal_pptx(path: Path, *slide_xml: str) -> None:
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("[Content_Types].xml", "<Types />")
+        archive.writestr("ppt/presentation.xml", f"<p:presentation xmlns:p='{P_NS}' />")
+        for index, slide in enumerate(slide_xml, 1):
+            archive.writestr(f"ppt/slides/slide{index}.xml", slide)
+
+
+def _simple_slide_xml(*text_runs: str) -> str:
+    runs = "".join(f"<a:r><a:rPr sz='2400'/><a:t>{text}</a:t></a:r>" for text in text_runs)
+    return (
+        "<?xml version='1.0' encoding='UTF-8' standalone='yes'?>"
+        f"<p:sld xmlns:a='{A_NS}' xmlns:p='{P_NS}'>"
+        "<p:cSld><p:spTree><p:sp><p:nvSpPr><p:cNvPr id='7' name='Text'/></p:nvSpPr>"
+        "<p:txBody><a:bodyPr/><a:lstStyle/>"
+        f"<a:p>{runs}</a:p>"
+        "</p:txBody></p:sp></p:spTree></p:cSld></p:sld>"
+    )
+
+
+def _simple_shape_xml(shape_id: int, text: str) -> str:
+    return (
+        f"<p:sp><p:nvSpPr><p:cNvPr id='{shape_id}' name='Text'/></p:nvSpPr>"
+        "<p:txBody><a:bodyPr/><a:lstStyle/><a:p>"
+        f"<a:r><a:t>{text}</a:t></a:r>"
+        "</a:p></p:txBody></p:sp>"
+    )
+
+
+def _table_slide_xml() -> str:
+    cells = "".join(
+        (
+            "<a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p>"
+            f"<a:r><a:t>{text}</a:t></a:r>"
+            "</a:p></a:txBody></a:tc>"
+        )
+        for text in ("Cell one", "Cell two")
+    )
+    return (
+        "<?xml version='1.0' encoding='UTF-8' standalone='yes'?>"
+        f"<p:sld xmlns:a='{A_NS}' xmlns:p='{P_NS}'><p:cSld><p:spTree>"
+        "<p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id='9' name='Table'/>"
+        "</p:nvGraphicFramePr><a:graphic><a:graphicData><a:tbl><a:tr>"
+        f"{cells}</a:tr></a:tbl></a:graphicData></a:graphic>"
+        "</p:graphicFrame></p:spTree></p:cSld></p:sld>"
+    )
+
+
+def _structured_slide_xml(*, required_prefix_only: bool = False) -> str:
+    compatibility = (
+        "<mc:AlternateContent><mc:Choice Requires='p14'><p:transition/></mc:Choice>"
+        "<mc:Fallback><p:transition/></mc:Fallback></mc:AlternateContent>"
+        if required_prefix_only
+        else ""
+    )
+    declarations = f" xmlns:mc='{MC_NS}' xmlns:p14='{P14_NS}' mc:Ignorable='p14'" if required_prefix_only else ""
+    return (
+        "<?xml version='1.0' encoding='UTF-8' standalone='yes'?>"
+        f"<p:sld xmlns:a='{A_NS}' xmlns:p='{P_NS}'{declarations}>"
+        "<p:cSld><p:spTree><p:sp><p:nvSpPr><p:cNvPr id='7' name='Text'/></p:nvSpPr>"
+        "<p:spPr><a:xfrm><a:off x='10' y='20'/><a:ext cx='3000' cy='4000'/></a:xfrm></p:spPr>"
+        "<p:txBody><a:bodyPr><a:noAutofit/></a:bodyPr><a:lstStyle/><a:p>"
+        "<a:r><a:rPr lang='en-US' sz='2400'/><a:t>Hello</a:t></a:r>"
+        "<a:br/><a:fld id='{A}' type='slidenum'><a:rPr/><a:t>1</a:t></a:fld>"
+        "<a:r><a:rPr lang='en-US' sz='1800'/><a:t>world</a:t></a:r>"
+        "</a:p></p:txBody></p:sp></p:spTree></p:cSld>"
+        f"{compatibility}</p:sld>"
+    )
+
+
+def _declared_prefixes(xml_data: bytes) -> set[str]:
+    return {
+        prefix
+        for _, (prefix, _) in ElementTree.iterparse(BytesIO(xml_data), events=("start-ns",))
+    }

--- a/tests/test_pptx_xml_translation.py
+++ b/tests/test_pptx_xml_translation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import zipfile
 import sys
+from io import BytesIO
 from pathlib import Path
 from xml.etree import ElementTree
 
@@ -140,6 +141,38 @@ def test_write_translated_pptx_xml_sets_textbox_autofit_when_text_is_appended(
     assert body_pr.find("a:noAutofit", NS) is None
 
 
+def test_write_translated_pptx_xml_keeps_prefix_required_by_compatibility_markup(
+    tmp_path: Path,
+) -> None:
+    from pptx_xml_translate import (
+        extract_text_boxes_data_from_pptx,
+        write_translated_pptx_xml,
+    )
+
+    pptx_path = tmp_path / "source.pptx"
+    output_path = tmp_path / "translated.pptx"
+    _write_minimal_pptx(pptx_path, _slide_xml_with_p14_transition("Hello"))
+    text_boxes = extract_text_boxes_data_from_pptx(pptx_path)
+
+    write_translated_pptx_xml(
+        pptx_path,
+        output_path,
+        text_boxes,
+        {0: {"translated_fragments": {"1_1": ["Bonjour"]}}},
+        "translation_only",
+    )
+
+    with zipfile.ZipFile(output_path) as archive:
+        slide_data = archive.read("ppt/slides/slide1.xml")
+    declared_prefixes = {
+        prefix
+        for _, (prefix, _) in ElementTree.iterparse(BytesIO(slide_data), events=("start-ns",))
+    }
+    assert "p14" in declared_prefixes, (
+        'PowerPoint cannot resolve mc:Choice Requires="p14" after slide XML is rewritten'
+    )
+
+
 def _write_minimal_pptx(path: Path, *slides: str) -> None:
     with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
         archive.writestr("[Content_Types].xml", "<Types />")
@@ -159,6 +192,23 @@ def _slide_xml(text_runs: list[str], body_pr_children: str = "") -> str:
         f"<p:cSld><p:spTree><p:sp><p:txBody><a:bodyPr>{body_pr_children}</a:bodyPr><a:lstStyle/>"
         f"<a:p>{runs}</a:p>"
         "</p:txBody></p:sp></p:spTree></p:cSld></p:sld>"
+    )
+
+
+def _slide_xml_with_p14_transition(text: str) -> str:
+    return (
+        "<?xml version='1.0' encoding='UTF-8' standalone='yes'?>"
+        f"<p:sld xmlns:a='{NS['a']}' xmlns:p='{NS['p']}' xmlns:r='{NS['r']}' "
+        "xmlns:mc='http://schemas.openxmlformats.org/markup-compatibility/2006' "
+        "xmlns:p14='http://schemas.microsoft.com/office/powerpoint/2010/main' "
+        "mc:Ignorable='p14'>"
+        "<p:cSld><p:spTree><p:sp><p:txBody><a:bodyPr/><a:lstStyle/>"
+        f"<a:p><a:r><a:t>{text}</a:t></a:r></a:p>"
+        "</p:txBody></p:sp></p:spTree></p:cSld>"
+        "<mc:AlternateContent><mc:Choice Requires='p14'>"
+        "<p:transition/></mc:Choice>"
+        "<mc:Fallback><p:transition/></mc:Fallback></mc:AlternateContent>"
+        "</p:sld>"
     )
 
 

--- a/tests/test_translation_providers.py
+++ b/tests/test_translation_providers.py
@@ -4,11 +4,16 @@ from dataclasses import dataclass, field
 
 import pytest
 
-from app.translation.providers import DeepSeekProvider, ProviderRegistry, QwenProvider
+from app.translation.providers import (
+    DeepSeekProvider,
+    ProviderRegistry,
+    QwenProvider,
+    _remote_data_text,
+)
 from app.translation.types import ProviderError, ProviderRequest
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class RecordingQwenTransport:
     response: str = '[{"box_index":1}]'
     calls: list[tuple[str, str, str, float]] = field(default_factory=list)
@@ -18,7 +23,7 @@ class RecordingQwenTransport:
         return self.response
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class RecordingRemoteTransport:
     response: str = '[{"box_index":1}]'
     calls: list[tuple[str, dict[str, str | bool], float]] = field(default_factory=list)
@@ -33,10 +38,10 @@ class TimeoutQwenTransport:
         raise TimeoutError("deadline")
 
 
-@dataclass(slots=True)
 class FailingQwenTransport:
-    error: Exception
-    calls: int = 0
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+        self.calls = 0
 
     def complete(self, model: str, system: str, user: str, timeout_seconds: float) -> str:
         self.calls += 1
@@ -87,6 +92,20 @@ def test_deepseek_provider_preserves_wire_payload_contract() -> None:
         "source_language": "English",
         "target_language": "Chinese",
     }
+
+
+def test_deepseek_structured_dict_response_is_serialized_as_json() -> None:
+    response = {
+        "translated_json": {
+            "provider_contract_schema_version": 2,
+            "document_kind": "pptx_xml",
+            "translations": [],
+        },
+    }
+
+    assert _remote_data_text(response) == (
+        '{"provider_contract_schema_version":2,"document_kind":"pptx_xml","translations":[]}'
+    )
 
 
 def test_registry_unknown_provider_has_no_fallback_call() -> None:

--- a/tests/test_translation_ux.py
+++ b/tests/test_translation_ux.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from flask import render_template
+from flask import Flask, render_template
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -69,7 +69,22 @@ def test_experience_styles_define_responsive_drawer_and_readable_type() -> None:
     assert "@media (prefers-reduced-motion: reduce)" in css
 
 
-def test_translation_templates_render_with_the_application_routes(isolated_app) -> None:
+def test_ppt_history_keeps_download_actions_visible() -> None:
+    template = _read(PPT_TEMPLATE)
+    css = _read(EXPERIENCE_CSS)
+
+    assert 'class="history-actions"' in template
+    assert 'class="history-mobile-meta"' in template
+    assert ".history-table th:last-child" in css
+    assert ".history-table td:last-child" in css
+    assert "min-width: 620px" in css
+    assert "table-layout: fixed !important" in css
+    assert "position: sticky" in css
+    assert "right: 0" in css
+    assert ".history-mobile-meta" in css
+
+
+def test_translation_templates_render_with_the_application_routes(isolated_app: Flask) -> None:
     with isolated_app.test_request_context("/"):
         ppt = render_template("main/index.html")
         pdf = render_template("main/pdf_translate.html")
@@ -77,3 +92,20 @@ def test_translation_templates_render_with_the_application_routes(isolated_app) 
     assert 'aria-current="page"' in ppt
     assert 'id="dropZone"' in ppt
     assert 'id="pdfUploadZone"' in pdf
+
+
+def test_login_template_exposes_local_credentials_and_keeps_sso(isolated_app: Flask) -> None:
+    # Given
+    with isolated_app.test_request_context("/auth/login"):
+        # When
+        login = render_template("auth/login.html", sso_enabled=True, sso_provider="oauth2")
+
+    # Then
+    assert '<form class="login-form" method="post" action="/auth/login">' in login
+    assert 'name="username"' in login
+    assert 'autocomplete="username"' in login
+    assert 'name="password"' in login
+    assert 'autocomplete="current-password"' in login
+    assert "账号密码登录" in login
+    assert 'href="/auth/sso/login"' in login
+    assert 'rel="icon" href="/static/images/logo.svg"' in login


### PR DESCRIPTION
## 变更内容

- 引入 PPTX XML 清单、包处理和结构化翻译模块，按稳定契约提取、翻译、校验并回写文本。
- 增加翻译结果契约校验、占位符保护、失败回退及提供商错误处理，降低损坏文件和异常译文风险。
- 完善 LibreOffice 转换阶段的输出校验与架构文档。
- 开启本地账号密码登录，同时保留企业 SSO。
- 修复翻译历史表格因长文件名横向溢出而遮挡下载按钮的问题，并适配移动端布局。
- 补充结构化 PPTX、翻译提供商和工作台交互的回归测试。

## 原因与影响

旧流程依赖较粗粒度的文本块处理，异常返回、占位符变化或 OOXML 包写回不完整时，可能出现 `[块]` 标记、文件需要 PowerPoint 修复或格式不稳定。新的结构化契约把提取、验证、回写和包完整性检查拆分为明确阶段，并保留兼容回退路径。

工作台历史记录此前使用自动表格布局，长文件名会把操作列推到可视区域之外。现在桌面端采用固定列布局，较窄视口固定操作列，手机端显示文件摘要和操作两列。

## 验证

- `python -m pytest -q`: 220 passed
- Playwright：1280x720 与 390x844 视口验证
- 浏览器控制台：0 errors
- `git diff --check`: passed